### PR TITLE
OMT-206 add custom compilemessages command

### DIFF
--- a/core/management/commands/compilemessages.py
+++ b/core/management/commands/compilemessages.py
@@ -1,0 +1,82 @@
+import glob
+import json
+import os
+from importlib import resources
+
+from django.core.management import CommandError
+from django.core.management.commands import compilemessages
+from django.core.management.utils import is_ignored_path, find_command
+
+
+class Command(compilemessages.Command):
+    def handle(self, **options):
+        locale = options['locale']
+        exclude = options['exclude']
+        ignore_patterns = set(options['ignore_patterns'])
+        self.verbosity = options['verbosity']
+        if options['fuzzy']:
+            self.program_options = self.program_options + ['-f']
+
+        if find_command(self.program) is None:
+            raise CommandError("Can't find %s. Make sure you have GNU gettext "
+                               "tools 0.15 or newer installed." % self.program)
+
+        basedirs = [os.path.join('conf', 'locale'), 'locale']
+        if os.environ.get('DJANGO_SETTINGS_MODULE'):
+            from django.conf import settings
+            basedirs.extend(settings.LOCALE_PATHS)
+
+        # Walk entire tree, looking for locale directories
+        apps = []
+        for mod in load_openimis_conf()["modules"]:
+            mod_name = mod["name"]
+            with resources.path(mod_name, "__init__.py") as path:
+                apps.append(path.parent.parent)  # This might need to be more restrictive
+
+        for topdir in ["."] + apps:
+            for dirpath, dirnames, filenames in os.walk(topdir, topdown=True):
+                for dirname in dirnames:
+                    if is_ignored_path(os.path.normpath(os.path.join(dirpath, dirname)), ignore_patterns):
+                        dirnames.remove(dirname)
+                    elif dirname == 'locale':
+                        basedirs.append(os.path.join(dirpath, dirname))
+
+        # Gather existing directories.
+        basedirs = set(map(os.path.abspath, filter(os.path.isdir, basedirs)))
+
+        if not basedirs:
+            raise CommandError("This script should be run from the Django Git "
+                               "checkout or your project or app tree, or with "
+                               "the settings module specified.")
+
+        # Build locale list
+        all_locales = []
+        for basedir in basedirs:
+            locale_dirs = filter(os.path.isdir, glob.glob('%s/*' % basedir))
+            all_locales.extend(map(os.path.basename, locale_dirs))
+
+        # Account for excluded locales
+        locales = locale or all_locales
+        locales = set(locales).difference(exclude)
+
+        self.has_errors = False
+        for basedir in basedirs:
+            if locales:
+                dirs = [os.path.join(basedir, l, 'LC_MESSAGES') for l in locales]
+            else:
+                dirs = [basedir]
+            locations = []
+            for ldir in dirs:
+                for dirpath, dirnames, filenames in os.walk(ldir):
+                    locations.extend((dirpath, f) for f in filenames if f.endswith('.po'))
+            if locations:
+                self.compile_messages(locations)
+
+        if self.has_errors:
+            raise CommandError('compilemessages generated one or more errors.')
+
+
+def load_openimis_conf():
+    conf_file_path = "../openimis.json"
+    with open(conf_file_path) as conf_file:
+        return json.load(conf_file)

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,30 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-05 10:45+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: core/core/utils.py:61 core/utils.py:76
+msgid "core.string.over_max_length"
+msgstr "Value %(value)s is over maximum length: %(max_length)s"
+
+#: core/core/utils.py:78 core/utils.py:93
+msgid "core.insuree.unknown_gender"
+msgstr "Unknown gender"
+
+#: core/core/utils.py:80 core/utils.py:95
+msgid "core.insuree.unknown_dob"
+msgstr "Unknown date of birth"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='openimis-be-core',
-    version='1.2.0-rc1',
+    version='1.2.0rc1',
     packages=find_packages(),
     include_package_data=True,
     license='GNU AGPL v3',


### PR DESCRIPTION
This command sadly has to duplicate a lot of the stock command's code to inject "locale" folders within each module.

This commands is in the core module because the root module has no application of itself to store the command.