### PR TITLE
OFS-99: enabling to filter deleted or non-deleted records

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -617,7 +617,7 @@ class HistoryModel(DirtyFieldsMixin, models.Model):
     def filter_queryset(cls, queryset=None):
         if queryset is None:
             queryset = cls.objects.all()
-        queryset = queryset.filter(filter_is_deleted())
+        queryset = queryset.filter()
         return queryset
 
     class Meta:


### PR DESCRIPTION
Pull request related to https://github.com/openimis/openimis-be-policyholder_py/pull/5 - allowing to filter by using "is_deleted" field. It is a small change. Now user can obtain non-deleted records by filtering "is_deleted"=False or deleted records by using "is_deleted"=True. As I wrote in pull id=5 for PolicyHolder repo I encountered some problems with filtering by default value of is_deleted=False and query doesn't work for is_deleted=True. That fix simply allow to filter also deleted record (so as to use "checkbox to show deleted" from PolicyHolder wiki in "PolicyHolder search page" section)