### PR TITLE
OFS-119: fixing bug related to mutation log in 'delete' mutation

### DIFF
--- a/core/gql/gql_mutations/base_mutation.py
+++ b/core/gql/gql_mutations/base_mutation.py
@@ -47,10 +47,9 @@ class BaseDeleteMutation(BaseMutation):
            for uuid in data["uuids"]:
                deletion_result = super(BaseDeleteMutation, cls)\
                    .async_mutate(user, uuid=uuid)
-               if deletion_result is None:
-                  deletion_result = [f'{uuid} is deleted']
+               deletion_result = [None] if deletion_result is None else ["error"]
                output += deletion_result
-           return output
+           return None if output == [None] * len(output) else output
 
 
 class BaseReplaceMutation(BaseMutation):


### PR DESCRIPTION
Could you merge this fix, because mutation log shows an error, but delete end successfully? @rstencel reported me this error. I had to change this. In mutation logs it must be 'None' so as to have status=2(success). Otherwise mutation log show "status=1" - (error) if we have output text.  

When the text is sent instead of None to the mutation_log - there is an error - mutation status has status=1 even if record is deleted (should be status 2).  