### PR TITLE
OFS:159: fix - filtering dates valid from/to (start, end date)

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -66,31 +66,35 @@ def filter_validity(arg='validity', **kwargs):
 def filter_validity_business_model(arg='dateValidFrom__Gte', arg2='dateValidTo__Lte', **kwargs):
     date_valid_from = kwargs.get(arg)
     date_valid_to = kwargs.get(arg2)
+    #default scenario
     if not date_valid_from and not date_valid_to:
-        validity = core.datetime.datetime.now()
-        return (
-            Q(date_valid_from=None) | Q(date_valid_from__lte=validity),
-            Q(date_valid_to=None) | Q(date_valid_to__gte=validity)
-        )
+        today = core.datetime.datetime.now()
+        return __place_the_filters(date_start=today, date_end=today)
 
-    if date_valid_from and not date_valid_to:
-        return (
-            Q(date_valid_from__gte=date_valid_from),
-            Q(date_valid_to__gte=date_valid_from) | Q(date_valid_to=None),
-        )
-
+    # scenario - only date valid to set
     if not date_valid_from and date_valid_to:
-        validity = core.datetime.datetime.now()
-        return (
-            Q(date_valid_from__lte=validity),
-            Q(date_valid_to__lte=date_valid_to) | Q(date_valid_to=None)
-        )
+        today = core.datetime.datetime.now()
+        oldest = min([today, date_valid_to])
+        return __place_the_filters(date_start=oldest, date_end=oldest)
 
+    # scenario - only date valid from
+    if date_valid_from and not date_valid_to:
+        return __place_the_filters(date_start=date_valid_from, date_end=date_valid_from)
+
+    # scenario - both filters set
     if date_valid_from and date_valid_to:
-        return (
-            Q(date_valid_from__lte=date_valid_from),
-            Q(date_valid_to__lte=date_valid_to) | Q(date_valid_to=None),
-        )
+        return __place_the_filters(date_start=date_valid_from, date_end=date_valid_to)
+
+
+def __place_the_filters(date_start, date_end):
+    """funtion related to 'filter_validity_business_model'
+    function so as to set up the chosen filters
+    to filter the validity of the entity
+    """
+    return (
+        Q(date_valid_from=None) | Q(date_valid_from__lte=date_start),
+        Q(date_valid_to=None) | Q(date_valid_to__gte=date_end)
+    )
 
 
 def filter_is_deleted(arg='is_deleted', **kwargs):

--- a/core/utils.py
+++ b/core/utils.py
@@ -79,7 +79,7 @@ def filter_validity_business_model(arg='dateValidFrom__Gte', arg2='dateValidTo__
 
     # scenario - only date valid from
     if date_valid_from and not date_valid_to:
-        return __place_the_filters(date_start=date_valid_from, date_end=date_valid_from)
+        return __place_the_filters(date_start=date_valid_from, date_end=None)
 
     # scenario - both filters set
     if date_valid_from and date_valid_to:
@@ -91,9 +91,14 @@ def __place_the_filters(date_start, date_end):
     function so as to set up the chosen filters
     to filter the validity of the entity
     """
+    if not date_end:
+        return (
+            Q(date_valid_from=None) | Q(date_valid_from__lte=date_start),
+            Q(date_valid_to=None) | Q(date_valid_to__gte=date_start)
+        )
     return (
-        Q(date_valid_from=None) | Q(date_valid_from__lte=date_start),
-        Q(date_valid_to=None) | Q(date_valid_to__gte=date_end)
+        Q(date_valid_from=None) | Q(date_valid_from__lte=date_end),
+        Q(date_valid_to=None) | Q(date_valid_to__gte=date_start)
     )
 
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -63,14 +63,34 @@ def filter_validity(arg='validity', **kwargs):
     )
 
 
-def filter_validity_business_model(arg='validity', **kwargs):
-    validity = kwargs.get(arg)
-    if validity is None:
+def filter_validity_business_model(arg='dateValidFrom__Gte', arg2='dateValidTo__Lte', **kwargs):
+    date_valid_from = kwargs.get(arg)
+    date_valid_to = kwargs.get(arg2)
+    if not date_valid_from and not date_valid_to:
         validity = core.datetime.datetime.now()
-    return (
-        Q(date_valid_from=None) | Q(date_valid_from__lte=validity),
-        Q(date_valid_to=None) | Q(date_valid_to__gte=validity)
-    )
+        return (
+            Q(date_valid_from=None) | Q(date_valid_from__lte=validity),
+            Q(date_valid_to=None) | Q(date_valid_to__gte=validity)
+        )
+
+    if date_valid_from and not date_valid_to:
+        return (
+            Q(date_valid_from__gte=date_valid_from),
+            Q(date_valid_to__gte=date_valid_from) | Q(date_valid_to=None),
+        )
+
+    if not date_valid_from and date_valid_to:
+        validity = core.datetime.datetime.now()
+        return (
+            Q(date_valid_from__lte=validity),
+            Q(date_valid_to__lte=date_valid_to) | Q(date_valid_to=None)
+        )
+
+    if date_valid_from and date_valid_to:
+        return (
+            Q(date_valid_from__lte=date_valid_from),
+            Q(date_valid_to__lte=date_valid_to) | Q(date_valid_to=None),
+        )
 
 
 def filter_is_deleted(arg='is_deleted', **kwargs):


### PR DESCRIPTION
In that PR I want to merge the function written in utils.py in Core module which return filters date_valid_from/date_valid_to on 4 scenarios:
- default scenario
- only date valid to (end) set
- only date valid from set
- both filters set