### PR TITLE
OFS-178: replace issues in HistoryModel/BusinessModel and datetime issue in that models 

### DIFF
--- a/core/datetimes/ad_datetime.py
+++ b/core/datetimes/ad_datetime.py
@@ -114,6 +114,8 @@ class AdDatetime(py_datetime.datetime):
         return self
 
     def __eq__(self, other):
+        if other is None:
+            return super(AdDatetime, self).__eq__(other)
         if isinstance(other, py_datetime.datetime):
             return super(AdDatetime, self).__eq__(other)
         if isinstance(other, py_datetime.date):

--- a/core/models.py
+++ b/core/models.py
@@ -612,6 +612,14 @@ class HistoryModel(DirtyFieldsMixin, models.Model):
             self.user_updated = user
             self.version = self.version + 1
             self.is_deleted = True
+            #check if we have business model
+            if hasattr(self, "replacement_uuid"):
+                # When a replacement entity is deleted, the link should be removed
+                # from replaced entity so a new replacement could be generated
+                replaced_entity = self.__class__.objects.get(replacement_uuid=self.id)
+                if replaced_entity:
+                    replaced_entity.replacement_uuid = None
+                    replaced_entity.save(username="admin")
             return super(HistoryModel, self).save()
         else:
             raise ValidationError('Record has not be deactivating, the object is different and must be updated before deactivating')

--- a/core/models.py
+++ b/core/models.py
@@ -598,8 +598,7 @@ class HistoryModel(DirtyFieldsMixin, models.Model):
             self.version = self.version + 1
             # check if we have business model
             if hasattr(self, "replacement_uuid"):
-                print(HistoryBusinessModel(self).replacement_uuid)
-                if HistoryBusinessModel(self).replacement_uuid is not None:
+                if self.replacement_uuid is not None and 'replacement_uuid' not in self.get_dirty_fields():
                     raise ValidationError('Update error! You cannot update replaced entity')
             return super(HistoryModel, self).save()
         else:

--- a/core/models.py
+++ b/core/models.py
@@ -596,6 +596,11 @@ class HistoryModel(DirtyFieldsMixin, models.Model):
             self.date_updated = now
             self.user_updated = user
             self.version = self.version + 1
+            # check if we have business model
+            if hasattr(self, "replacement_uuid"):
+                print(HistoryBusinessModel(self).replacement_uuid)
+                if HistoryBusinessModel(self).replacement_uuid is not None:
+                    raise ValidationError('Update error! You cannot update replaced entity')
             return super(HistoryModel, self).save()
         else:
             raise ValidationError('Record has not be updated - there are no changes in fields')


### PR DESCRIPTION
In that pull request I want to fix some issues in Core module with HistoryModel and HistoryBusinessModel. There are three changes, two requested by Patrick @delcroip and one detected by me with using core datetime and date fields type instead of default django ones (model.DateTime etc).
1. using core Date and DateTime type instead of default django one according to the clues given by BlueSquare ("openIMIS dates management (backend and frontend)" in https://openimis.atlassian.net/wiki/spaces/OP/pages/1938489348/2020-11-19+Developer+training+material+Q+A).
2. Replaced entity should not be updatable (requested by Patrick)
3. When a replacement entity is deleted, the link should be removed from replaced entity so a new replacement could be generated (requested by Patrick)

To the point 1 - the migrations should be applied in modules, I also created PR in Calculation, PH and CP modules. 
- CP and CPB module - https://github.com/openimis/openimis-be-contribution_plan_py/pull/21
-  PH module - https://github.com/openimis/openimis-be-policyholder_py/pull/24
- Calculation module - https://github.com/openimis/openimis-be-calculation_py/pull/3
- later with update Contract ticket I will merge this migration to the Contract module with update Service etc.
Moreover I had to add in " core/datetimes/ad_datetime.py " one condition because django dirty fields wasn't able to compare core.Datetime with None/Null values as standard django default DateTime can do it. That is why I added the comment in this change in that class AdDatetime etc.
