### PR TITLE
OFS-136: adding overridden Signal class so as to add priority

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -1,0 +1,13 @@
+from django.dispatch import Signal as BaseSignal
+from django.dispatch.dispatcher import _make_id
+
+
+class Signal(BaseSignal):
+
+    def connect(self, receiver, sender=None, weak=True, dispatch_uid=None, priority=50):
+        if dispatch_uid is None:
+            dispatch_uid = _make_id(receiver)
+
+        inner_uid = '{0}{1}'.format(priority, dispatch_uid)
+        super(Signal, self).connect(receiver, sender=sender, weak=weak, dispatch_uid=inner_uid)
+        self.receivers.sort()


### PR DESCRIPTION
In that PR I want to add overriden Signal class to the Core module according to the idea from https://openimis.atlassian.net/wiki/spaces/OP/pages/1730740234/Calculations+Module and https://stackoverflow.com/questions/10017567/possible-to-change-order-of-django-signals