### PR TITLE
OFS-229: createRole and updateRole mutations

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -24,6 +24,11 @@ DEFAULT_CFG = {
     "async_mutations": "False",
     "currency": "$",
     "gql_query_roles_perms": ["122001"],
+    "gql_mutation_create_roles_perms": ["122002"],
+    "gql_mutation_update_roles_perms": ["122003"],
+    "gql_mutation_replace_roles_perms": ["122006"],
+    "gql_mutation_duplicate_roles_perms": ["122005"],
+    "gql_mutation_delete_roles_perms": ["122004"],
 }
 
 
@@ -31,6 +36,11 @@ class CoreConfig(AppConfig):
     name = MODULE_NAME
     age_of_majority = 18
     gql_query_roles_perms = []
+    gql_mutation_create_roles_perms = []
+    gql_mutation_update_roles_perms = []
+    gql_mutation_replace_roles_perms = []
+    gql_mutation_duplicate_roles_perms = []
+    gql_mutation_delete_roles_perms = []
 
     def _import_module(self, cfg, k):
         logger.info('import %s.%s' %
@@ -83,6 +93,16 @@ class CoreConfig(AppConfig):
     def _configure_permissions(self, cfg):
         CoreConfig.gql_query_roles_perms = cfg[
             "gql_query_roles_perms"]
+        CoreConfig.gql_mutation_create_roles_perms = cfg[
+            "gql_mutation_create_roles_perms"]
+        CoreConfig.gql_mutation_update_roles_perms = cfg[
+            "gql_mutation_update_roles_perms"]
+        CoreConfig.gql_mutation_replace_roles_perms = cfg[
+            "gql_mutation_replace_roles_perms"]
+        CoreConfig.gql_mutation_duplicate_roles_perms = cfg[
+            "gql_mutation_duplicate_roles_perms"]
+        CoreConfig.gql_mutation_delete_roles_perms = cfg[
+            "gql_mutation_delete_roles_perms"]
 
     def ready(self):
         from .models import ModuleConfiguration

--- a/core/models.py
+++ b/core/models.py
@@ -265,7 +265,7 @@ class TechnicalUser(AbstractBaseUser):
 
 class Role(VersionedModel):
     id = models.AutoField(db_column='RoleID', primary_key=True)
-    uuid = models.CharField(db_column='RoleUUID', max_length=36)
+    uuid = models.CharField(db_column='RoleUUID', max_length=36, default=uuid.uuid4, unique=True)
     name = models.CharField(db_column='RoleName', max_length=50)
     alt_language = models.CharField(
         db_column='AltLanguage', max_length=50, blank=True, null=True)

--- a/core/schema.py
+++ b/core/schema.py
@@ -409,7 +409,7 @@ def update_or_create_role(data, user):
         role.save_history()
         [setattr(role, k, v) for k, v in data.items()]
         role.save()
-        if rights_id:
+        if rights_id is not None:
             # reset all role rights assigned to the chosen role
             from core import datetime
             now = datetime.datetime.now()

--- a/core/schema.py
+++ b/core/schema.py
@@ -465,8 +465,6 @@ class CreateRoleMutation(OpenIMISMutation):
                 raise ValidationError("mutation.authentication_required")
             if not user.has_perms(CoreConfig.gql_mutation_create_roles_perms):
                 raise PermissionDenied("unauthorized")
-            if not user.has_perms(CoreConfig.gql_mutation_create_roles_perms):
-                raise PermissionDenied("unauthorized")
             from core.utils import TimeUtils
             data['validity_from'] = TimeUtils.now()
             data['audit_user_id'] = user.id_for_audit

--- a/core/schema.py
+++ b/core/schema.py
@@ -480,7 +480,7 @@ class CreateRoleMutation(OpenIMISMutation):
 
 class UpdateRoleMutation(OpenIMISMutation):
     """
-    Update a new role, with its chosen role right
+    Update a chosen role, with its chosen role right
     """
     _mutation_module = "core"
     _mutation_class = "UpdateRoleMutation"
@@ -503,7 +503,7 @@ class UpdateRoleMutation(OpenIMISMutation):
         except Exception as exc:
             return [
                 {
-                    'message': "core.mutation.failed_to_create_role",
+                    'message': "core.mutation.failed_to_update_role",
                     'detail': str(exc)
                 }]
 

--- a/core/schema.py
+++ b/core/schema.py
@@ -495,7 +495,7 @@ class UpdateRoleMutation(OpenIMISMutation):
         try:
             if type(user) is AnonymousUser or not user.id:
                 raise ValidationError("mutation.authentication_required")
-            if not user.has_perms(CoreConfig.gql_mutation_create_roles_perms):
+            if not user.has_perms(CoreConfig.gql_mutation_update_roles_perms):
                 raise PermissionDenied("unauthorized")
             if 'uuid' not in data:
                 raise ValidationError("There is no uuid in updateMutation input!")

--- a/core/schema.py
+++ b/core/schema.py
@@ -421,7 +421,7 @@ def update_or_create_role(data, user):
                 **{
                     "role_id": role.id,
                     "right_id": int(right_id),
-                    "audit_user_id": role.audit_user_id if role.audit_user_id else None,
+                    "audit_user_id": role.audit_user_id,
                     "validity_from": now,
                 }
             ) for right_id in rights_id]
@@ -433,7 +433,7 @@ def update_or_create_role(data, user):
                 **{
                     "role_id": role.id,
                     "right_id": int(right_id),
-                    "audit_user_id": role.audit_user_id if role.audit_user_id else None,
+                    "audit_user_id": role.audit_user_id,
                     "validity_from": now,
                    }
             ) for right_id in rights_id]


### PR DESCRIPTION
TICKETS: OFS-229 https://openimis.atlassian.net/browse/OFS-229 - create and update mutation
and partially - with adding perms - https://openimis.atlassian.net/browse/OFS-230 - OFS-230

In that PR I want to add create and update Role graphQl mutations. Also I added perms for that and another future mutations in apps.py of Core module.

Moreover I had to modify uuid field in Role model into 
`uuid = models.CharField(db_column='RoleUUID', max_length=36, default=uuid.uuid4, unique=True)`
with adding "default=uuid.uuid4, unique=True" because without it the uuid for a new Role wasn't created properly and there were some issues on backend during creating a whole new Role.

The rest of mutations for Role will be merged in another PR. 