### PR TITLE
OFS-254: adding new validity flag for business entities FS

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -102,6 +102,22 @@ def __place_the_filters(date_start, date_end):
     )
 
 
+def append_validity_filter(**kwargs):
+    default_filter = kwargs.get('setDefaultFilter', False)
+    date_valid_from = kwargs.get('dateValidFrom__Gte', None)
+    date_valid_to = kwargs.get('dateValidTo__Lte', None)
+    filters = []
+    # check if we can use default filter validity
+    if date_valid_from is None and date_valid_to is None:
+        if default_filter:
+            filters = [*filter_validity_business_model(**kwargs)]
+        else:
+            filters = []
+    else:
+        filters = [*filter_validity_business_model(**kwargs)]
+    return filters
+
+
 def filter_is_deleted(arg='is_deleted', **kwargs):
     is_deleted = kwargs.get(arg)
     if is_deleted is None:

--- a/core/utils.py
+++ b/core/utils.py
@@ -103,7 +103,7 @@ def __place_the_filters(date_start, date_end):
 
 
 def append_validity_filter(**kwargs):
-    default_filter = kwargs.get('setDefaultFilter', False)
+    default_filter = kwargs.get('applyDefaultValidityFilter', False)
     date_valid_from = kwargs.get('dateValidFrom__Gte', None)
     date_valid_to = kwargs.get('dateValidTo__Lte', None)
     filters = []


### PR DESCRIPTION
Ticket - https://openimis.atlassian.net/browse/OFS-254 - 1 issue with filtering validity for FS entities 

In that PR I want to add function to append filtering validity or in case of setting special flag - returning no filters if in graphQl somebody want to not filter by default one.

It will be used for schema in FS modules. (HistoryBusinessModel)