### PR TITLE
OE0-4: change the way of checking config for permissions

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -545,7 +545,7 @@ class Query(graphene.ObjectType):
                 config_dict = ModuleConfiguration.get_or_default(f"{app}", apps.apps.DEFAULT_CFG)
                 permission = []
                 for key, value in config_dict.items():
-                    if "gql_query" in key or "gql_mutation" in key:
+                    if key.endswith("_perms"):
                         if isinstance(value, list):
                             for val in value:
                                 permission.append(PermissionOpenImisGQLType(


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OE0-4

then we can show in perms another permissions not only related to graphQL etc. 
![Screenshot from 2021-06-29 12-19-39](https://user-images.githubusercontent.com/52816247/123782625-d0f0ae80-d8d5-11eb-8181-bea74a0d2add.png)
