### PR TITLE
Move JWT modules from main to core

### DIFF
--- a/core/jwt.py
+++ b/core/jwt.py
@@ -1,0 +1,82 @@
+# from graphql_auth.backends import GraphQLAuthBackend
+# from django.utils.deprecation import MiddlewareMixin
+import jwt
+from graphql_jwt.settings import jwt_settings
+from django.apps import apps
+
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+def jwt_encode_user_key(payload, context=None):
+    token = jwt.encode(
+        payload,
+        get_jwt_key(encode=True, context=context),
+        jwt_settings.JWT_ALGORITHM,
+    )
+    # JWT module after 1.7 does the encoding, introducing some conflicts in graphql-jwt, let's support both
+    if isinstance(token, bytes):
+        token = token.decode("utf-8")
+    return token
+
+
+def jwt_decode_user_key(token, context=None):
+    # First decode the token without validating it, so we can extract the username
+    not_validated = jwt.decode(
+        token,
+        get_jwt_key(encode=False, context=context),
+        options={
+            'verify_exp': jwt_settings.JWT_VERIFY_EXPIRATION,
+            'verify_aud': jwt_settings.JWT_AUDIENCE is not None,
+            'verify_signature': False,
+        },
+        leeway=jwt_settings.JWT_LEEWAY,
+        audience=jwt_settings.JWT_AUDIENCE,
+        issuer=jwt_settings.JWT_ISSUER,
+        algorithms=[jwt_settings.JWT_ALGORITHM],
+    )
+    if not_validated and not_validated.get("username"):
+        user_class = apps.get_model("core", "User")
+        db_user = user_class.objects\
+            .filter(username=not_validated.get("username"))\
+            .only("i_user__private_key")\
+            .first()
+        if db_user and db_user.private_key:
+            key = db_user.private_key
+        else:
+            key = get_jwt_key(encode=False)
+    else:
+        key = get_jwt_key(encode=False)
+    return jwt.decode(
+        token,
+        key,
+        options={
+            'verify_exp': jwt_settings.JWT_VERIFY_EXPIRATION,
+            'verify_aud': jwt_settings.JWT_AUDIENCE is not None,
+            'verify_signature': jwt_settings.JWT_VERIFY,
+        },
+        leeway=jwt_settings.JWT_LEEWAY,
+        audience=jwt_settings.JWT_AUDIENCE,
+        issuer=jwt_settings.JWT_ISSUER,
+        algorithms=[jwt_settings.JWT_ALGORITHM],
+    )
+
+
+def get_jwt_key(encode=True, context=None):
+    user_key = extract_private_key_from_context(context)
+    if user_key:
+        return user_key
+    if encode:
+        if hasattr(jwt_settings, "JWT_PRIVATE_KEY"):
+            return jwt_settings.JWT_PRIVATE_KEY
+    else:
+        if hasattr(jwt_settings, "JWT_PUBLIC_KEY"):
+            return jwt_settings.JWT_PUBLIC_KEY
+    return jwt_settings.JWT_SECRET_KEY
+
+
+def extract_private_key_from_context(context):
+    if context and context.user and hasattr(context.user, "private_key"):
+        return context.user.private_key
+    return None

--- a/core/jwt_authentication.py
+++ b/core/jwt_authentication.py
@@ -1,0 +1,74 @@
+from .jwt import jwt_decode_user_key
+
+from django.apps import apps
+from django.middleware.csrf import CsrfViewMiddleware
+from rest_framework.authentication import BaseAuthentication
+from rest_framework import exceptions
+
+import jwt
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+class CSRFCheck(CsrfViewMiddleware):
+    def _reject(self, request, reason):
+        # Return the failure reason instead of an HttpResponse
+        return reason
+
+
+class JWTAuthentication(BaseAuthentication):
+    """
+        class to obtain token from header if it is provided
+        and verify if this is correct/valid token
+    """
+
+    def authenticate(self, request):
+        authorization_header = request.headers.get('Authorization')
+        if not authorization_header:
+            return None
+        payload = None
+        if authorization_header.lower().startswith('bearer '):
+            bearer, access_token, *extra_words = authorization_header.split(' ')
+            if len(extra_words) > 0:
+                raise exceptions.AuthenticationFailed("Unproper structure of token")
+            try:
+                payload = jwt_decode_user_key(token=access_token)
+            except jwt.DecodeError:
+                raise exceptions.AuthenticationFailed('Error on decoding token')
+            except jwt.ExpiredSignatureError:
+                raise exceptions.AuthenticationFailed('Access_token expired')
+            except IndexError:
+                raise exceptions.AuthenticationFailed('Token prefix missing')
+            user = None
+            if payload:
+                user_class = apps.get_model("core", "User")
+                user = user_class.objects \
+                    .filter(username=payload.get("username")) \
+                    .only("i_user__private_key") \
+                    .first()
+            if user is None:
+                raise exceptions.AuthenticationFailed('User inactive or deleted/not existed.')
+            if not user.is_active:
+                raise exceptions.AuthenticationFailed('User is inactive')
+        else:
+            raise exceptions.AuthenticationFailed("Missing 'Bearer' prefix")
+
+        self.enforce_csrf(request)
+
+        return user, None
+
+
+    def enforce_csrf(self, request):
+        """
+        Enforce CSRF validation
+        """
+        check = CSRFCheck()
+        # populates request.META['CSRF_COOKIE'], which is used in process_view()
+        check.process_request(request)
+        reason = check.process_view(request, None, (), {})
+        logger.debug(reason)
+        if reason:
+            # CSRF failed, bail with explicit error message
+            raise exceptions.PermissionDenied('CSRF Failed: %s' % reason)
+

--- a/core/schema.py
+++ b/core/schema.py
@@ -24,6 +24,7 @@ from django.http import HttpRequest
 from django.utils import translation
 from graphene.utils.str_converters import to_snake_case
 from graphene_django.filter import DjangoFilterConnectionField
+import graphql_jwt
 from typing import Optional
 
 from .apps import CoreConfig
@@ -1076,6 +1077,12 @@ class Mutation(graphene.ObjectType):
     update_user = UpdateUserMutation.Field()
     delete_user = DeleteUserMutation.Field()
     change_password = ChangePasswordMutation.Field()
+
+    token_auth = graphql_jwt.mutations.ObtainJSONWebToken.Field()
+    verify_token = graphql_jwt.mutations.Verify.Field()
+    refresh_token = graphql_jwt.mutations.Refresh.Field()
+    revoke_token = graphql_jwt.mutations.Revoke.Field()
+
 
 
 def on_role_mutation(sender, **kwargs):


### PR DESCRIPTION
As discussed on Skype, move JWT token config modules to the core rather than main assembly module.

To be tested before merging.