### PR TITLE
OE0-2: remove enforce_csrf validation after detecting issue on test server.

### DIFF
--- a/core/jwt_authentication.py
+++ b/core/jwt_authentication.py
@@ -1,7 +1,6 @@
 from .jwt import jwt_decode_user_key
 
 from django.apps import apps
-from django.middleware.csrf import CsrfViewMiddleware
 from rest_framework.authentication import BaseAuthentication
 from rest_framework import exceptions
 
@@ -9,12 +8,6 @@ import jwt
 import logging
 
 logger = logging.getLogger(__file__)
-
-
-class CSRFCheck(CsrfViewMiddleware):
-    def _reject(self, request, reason):
-        # Return the failure reason instead of an HttpResponse
-        return reason
 
 
 class JWTAuthentication(BaseAuthentication):
@@ -54,21 +47,4 @@ class JWTAuthentication(BaseAuthentication):
         else:
             raise exceptions.AuthenticationFailed("Missing 'Bearer' prefix")
 
-        self.enforce_csrf(request)
-
         return user, None
-
-
-    def enforce_csrf(self, request):
-        """
-        Enforce CSRF validation
-        """
-        check = CSRFCheck()
-        # populates request.META['CSRF_COOKIE'], which is used in process_view()
-        check.process_request(request)
-        reason = check.process_view(request, None, (), {})
-        logger.debug(reason)
-        if reason:
-            # CSRF failed, bail with explicit error message
-            raise exceptions.PermissionDenied('CSRF Failed: %s' % reason)
-

--- a/core/jwt_authentication.py
+++ b/core/jwt_authentication.py
@@ -47,4 +47,10 @@ class JWTAuthentication(BaseAuthentication):
         else:
             raise exceptions.AuthenticationFailed("Missing 'Bearer' prefix")
 
+        self.enforce_csrf(request)
+
         return user, None
+
+    def enforce_csrf(self, request):
+        return  # To not perform the csrf during checking auth header
+


### PR DESCRIPTION
hotfix for Ticket https://openimis.atlassian.net/browse/OE0-2 after deployment on modular-fs test server

I needed to remove this because when I was trying to make a request and send in RESTED client then I received CSRF error validation during callings some endpoints defined on modular. ""CSRF Failed: CSRF token missing or incorrect."" This should not enforce validating csrf during validation of auth header.

Affected environment: https://modular.fs.swisstph-mis.ch/