### PR TITLE
Json configuration loaded as OrderedDict

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -144,7 +144,8 @@ class ModuleConfiguration(UUIDModel):
 
     @cached_property
     def _cfg(self):
-        return json.loads(self.config)
+        import collections
+        return json.loads(self.config, object_pairs_hook=collections.OrderedDict)
 
     def __str__(self):
         return "%s [%s]" % (self.module, self.version)


### PR DESCRIPTION
json.loads by defaut does not ensure that the data is loaded in the order specified in the custom config. The configuration order can be important in some cases (e.g. PolicyNotification module). Using OrderedDict solve this issue. 