### PR TITLE
Cannot connect with non-admin user OMT-281

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,7 @@
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 from .models import User
 from .serializers import UserSerializer
 
@@ -8,6 +9,9 @@ from .serializers import UserSerializer
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    # If we don't specify the IsAuthenticated, the framework will look for the core.user_view permission and prevent
+    # any access from non-admin users
+    permission_classes = [IsAuthenticated]
 
     @action(detail=False)
     def current_user(self, request):


### PR DESCRIPTION
This is not exactly OMT-281 but being unable to connect with a claim administrator prevents the test at all.

As pointed out in the comment, by default, the rest framework will look for core.user_view permission among the numeric permissions of openIMIS and obviously deny access. Explicitly setting the permission on that specific view allows any authenticated user to view their own data, as intended. Unauthenticated users will still get a 403 response.