### PR TITLE
calc rule calculate() should not name first arg

### DIFF
--- a/core/abs_calculation_rule.py
+++ b/core/abs_calculation_rule.py
@@ -100,7 +100,7 @@ class AbsCalculationRule(object,  metaclass=abc.ABCMeta):
 
     @classmethod
     @abc.abstractmethod
-    def calculate(cls, instance, *args):
+    def calculate(cls, instance, *args, **kwargs):
         return
 
     @classmethod
@@ -152,7 +152,7 @@ class AbsCalculationRule(object,  metaclass=abc.ABCMeta):
                     if cls.active_for_object(instance=instance, context=context):
                         # add context to kwargs
                         kwargs["context"] = context
-                        result = cls.calculate(instance=instance, **kwargs)
+                        result = cls.calculate(instance, **kwargs)
                         return result
 
     @classmethod


### PR DESCRIPTION
The method was declared as `instance, *args` so calling calculate(instance=instance, *args) failed with unexpected parameter signal (first kwargs). Calling the method with instance=instance makes it a named argument, so you can't pass any positional argument after that. That proper way is for methods to accept both *args and **kwargs and then call with instance as positional, the *args will add more positional arguments and then **kwargs can be passed.

This makes the contract module test properly.