### PR TITLE
OPL-54: Move BaseService and BaseModelValidation to core module

### DIFF
--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -1,0 +1,5 @@
+from core.services.base import BaseService
+from core.services.userServices import create_or_update_interactive_user, create_or_update_user_roles, \
+    create_or_update_user_districts, create_or_update_officer_villages, create_or_update_officer, \
+    create_or_update_claim_admin, create_or_update_core_user, change_user_password, set_user_password, \
+    reset_user_password

--- a/core/services/base.py
+++ b/core/services/base.py
@@ -1,0 +1,74 @@
+from abc import ABC
+from typing import Type
+
+from django.db import transaction
+
+from core.models import HistoryModel
+from core.services.utils import check_authentication as check_authentication, output_exception, \
+    model_representation, output_result_success, build_delete_instance_payload
+from core.validation.base import BaseModelValidation
+
+
+class BaseService(ABC):
+
+    @property
+    def OBJECT_TYPE(self) -> Type[HistoryModel]:
+        """
+        Django ORM model. It's expected that it'll be inheriting from HistoryModel.
+        """
+        raise NotImplementedError("Class has to define OBJECT_TYPE for service.")
+
+    def __init__(self, user, validation_class: BaseModelValidation):
+        self.user = user
+        self.validation_class = validation_class
+
+    @check_authentication
+    def create(self, obj_data):
+        try:
+            with transaction.atomic():
+                obj_data = self._adjust_create_payload(obj_data)
+                self.validation_class.validate_create(self.user, **obj_data)
+                obj_ = self.OBJECT_TYPE(**obj_data)
+                return self.save_instance(obj_)
+        except Exception as exc:
+            return output_exception(model_name="Invoice", method="create", exception=exc)
+
+    @check_authentication
+    def update(self, obj_data):
+        try:
+            with transaction.atomic():
+                obj_data = self._adjust_update_payload(obj_data)
+                self.validation_class.validate_update(self.user, **obj_data)
+                obj_ = self.OBJECT_TYPE.objects.filter(id=obj_data['id']).first()
+                [setattr(obj_, key, obj_data[key]) for key in obj_data]
+                return self.save_instance(obj_)
+        except Exception as exc:
+            return output_exception(model_name="Invoice", method="update", exception=exc)
+
+    @check_authentication
+    def delete(self, obj_data):
+        try:
+            with transaction.atomic():
+                self.validation_class.validate_delete(self.user, **obj_data)
+                obj_ = self.OBJECT_TYPE.objects.filter(id=obj_data['id']).first()
+                return self.delete_instance(obj_)
+        except Exception as exc:
+            return output_exception(model_name="Invoice", method="delete", exception=exc)
+
+    def save_instance(self, obj_):
+        obj_.save(username=self.user.username)
+        dict_repr = model_representation(obj_)
+        return output_result_success(dict_representation=dict_repr)
+
+    def delete_instance(self, obj_):
+        obj_.delete(username=self.user.username)
+        return build_delete_instance_payload()
+
+    def _adjust_create_payload(self, payload_data):
+        return self._base_payload_adjust(payload_data)
+
+    def _adjust_update_payload(self, payload_data):
+        return self._base_payload_adjust(payload_data)
+
+    def _base_payload_adjust(self, obj_data):
+        return obj_data

--- a/core/services/userServices.py
+++ b/core/services/userServices.py
@@ -1,15 +1,16 @@
-from core.apps import CoreConfig
+import logging
+from gettext import gettext as _
+
 from django.apps import apps
-from core.models import User, InteractiveUser, Officer, UserRole
+from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.mail import send_mail, BadHeaderError
-from django.conf import settings
 from django.template import loader
 from django.utils.http import urlencode
 
-import logging
-from gettext import gettext as _
+from core.apps import CoreConfig
+from core.models import User, InteractiveUser, Officer, UserRole
 
 logger = logging.getLogger(__file__)
 
@@ -216,9 +217,7 @@ def create_or_update_core_user(user_uuid, username, i_user=None, t_user=None, of
     return user, created
 
 
-def change_user_password(
-    logged_user, username_to_update=None, old_password=None, new_password=None
-):
+def change_user_password(logged_user, username_to_update=None, old_password=None, new_password=None):
     if username_to_update and username_to_update != logged_user.username:
         if not logged_user.has_perms(CoreConfig.gql_mutation_update_users_perms):
             raise PermissionDenied("unauthorized")

--- a/core/services/utils/__init__.py
+++ b/core/services/utils/__init__.py
@@ -1,0 +1,2 @@
+from core.services.utils.serviceUtils import check_authentication, model_representation, output_exception, \
+    output_result_success, build_delete_instance_payload, get_generic_type

--- a/core/services/utils/serviceUtils.py
+++ b/core/services/utils/serviceUtils.py
@@ -1,0 +1,64 @@
+import json
+from typing import Union
+
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.contenttypes.models import ContentType
+from django.core.serializers.json import DjangoJSONEncoder
+from django.forms.models import model_to_dict
+
+
+def check_authentication(function):
+    def wrapper(self, *args, **kwargs):
+        if type(self.user) is AnonymousUser or not self.user.id:
+            return {
+                "success": False,
+                "message": "Authentication required",
+                "detail": "PermissionDenied",
+            }
+        else:
+            result = function(self, *args, **kwargs)
+            return result
+
+    return wrapper
+
+
+def model_representation(model):
+    uuid_string = str(model.id)
+    dict_representation = model_to_dict(model)
+    dict_representation["id"], dict_representation["uuid"] = (str(uuid_string), str(uuid_string))
+    return dict_representation
+
+
+def output_exception(model_name, method, exception):
+    return {
+        "success": False,
+        "message": f"Failed to {method} {model_name}",
+        "detail": str(exception),
+        "data": "",
+    }
+
+
+def output_result_success(dict_representation):
+    return {
+        "success": True,
+        "message": "Ok",
+        "detail": "",
+        "data": json.loads(json.dumps(dict_representation, cls=DjangoJSONEncoder)),
+    }
+
+
+def build_delete_instance_payload():
+    return {
+        "success": True,
+        "message": "Ok",
+        "detail": "",
+    }
+
+
+def get_generic_type(generic_type: Union[str, ContentType]):
+    if isinstance(generic_type, ContentType):
+        return generic_type
+    elif isinstance(generic_type, str):
+        return ContentType.objects.get(model=generic_type.lower())
+    else:
+        return ContentType.objects.get(model=str(generic_type).lower())

--- a/core/validation/__init__.py
+++ b/core/validation/__init__.py
@@ -1,0 +1,3 @@
+from core.validation.base import BaseModelValidation
+from core.validation.uniqueCodeValidationMixin import UniqueCodeValidationMixin
+from core.validation.objectExistsValidationMixin import ObjectExistsValidationMixin

--- a/core/validation/base.py
+++ b/core/validation/base.py
@@ -1,0 +1,30 @@
+from abc import ABC
+from typing import Type
+
+from core.models import HistoryModel
+
+
+class BaseModelValidation(ABC):
+    """
+    Base validation class, by default all operations are unconditionally allowed.
+    Validation methods should raise ValidationError in case of any data inconsistencies.
+    """
+
+    @property
+    def OBJECT_TYPE(self) -> Type[HistoryModel]:
+        """
+        Django ORM model. It's expected that it'll be inheriting from HistoryModel.
+        """
+        raise NotImplementedError("Class has to define OBJECT_TYPE for service.")
+
+    @classmethod
+    def validate_create(cls, user, **data):
+        pass
+
+    @classmethod
+    def validate_update(cls, user, **data):
+        pass
+
+    @classmethod
+    def validate_delete(cls, user, **data):
+        pass

--- a/core/validation/objectExistsValidationMixin.py
+++ b/core/validation/objectExistsValidationMixin.py
@@ -1,0 +1,12 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+
+
+class ObjectExistsValidationMixin:
+    INVALID_UPDATE_ID_MSG = _("%(model)s for id  %(id)s does not exists")
+
+    @classmethod
+    def validate_object_exists(cls, id_):
+        existing = cls.OBJECT_TYPE.objects.filter(id=id_).first()
+        if not existing:
+            raise ValidationError(cls.INVALID_UPDATE_ID_MSG % {'id': id_, 'model': str(cls.OBJECT_TYPE)})

--- a/core/validation/uniqueCodeValidationMixin.py
+++ b/core/validation/uniqueCodeValidationMixin.py
@@ -1,0 +1,19 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+
+
+class UniqueCodeValidationMixin:
+    CODE_DUPLICATE_MSG = _("Object code %(code)s is not unique.")
+
+    @classmethod
+    def validate_unique_code_name(cls, code, excluded_id=None, code_key='code'):
+        if not cls._unique_code_name(code, excluded_id, code_key=code_key):
+            raise ValidationError(cls.CODE_DUPLICATE_MSG % {'code': code})
+
+    @classmethod
+    def _unique_code_name(cls, code, excluded_id=None, code_key='code'):
+        query = cls.OBJECT_TYPE.objects.filter(**{code_key: code})
+        if excluded_id:
+            query = query.exclude(id=excluded_id)
+
+        return not query.exists()


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OPL-54](https://openimis.atlassian.net/browse/OPL-54)

Changes:
- Moved BaseService and BaseModelValidation to from `invoice` to `core` module (to reuse in fhir `module` for subscription resource)