### PR TITLE
OPL-57: Fix compability of HistoryModel with django rest framework

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -879,7 +879,10 @@ class HistoryModel(DirtyFieldsMixin, models.Model):
         pass
 
     def delete(self, *args, **kwargs):
-        user = User.objects.get(**kwargs)
+        if 'username' in kwargs:
+            user = User.objects.get(username=kwargs.pop('username'))
+        else:
+            raise ValidationError('Delete error! Provide the username of the current user in `username` argument')
         if not self.is_dirty(check_relationship=True) and not self.is_deleted:
             from core import datetime
             now = datetime.datetime.now()
@@ -895,7 +898,7 @@ class HistoryModel(DirtyFieldsMixin, models.Model):
                 if replaced_entity:
                     replaced_entity.replacement_uuid = None
                     replaced_entity.save(username="admin")
-            return super(HistoryModel, self).save()
+            return super(HistoryModel, self).save(*args, **kwargs)
         else:
             raise ValidationError(
                 'Record has not be deactivating, the object is different and must be updated before deactivating')


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OPL-57](https://openimis.atlassian.net/browse/OPL-57)
This PR depends on https://github.com/openimis/openimis-be-core_py/pull/109

Changes:
- Added `args` and `kwargs` to `super().save()` and `super().delete()` calls
- Added "popping" of username provided to `save` and `delete` method from arguments before sending it back to ORM.