### PR TITLE
OTC-717 Implement generic way to extend GQL Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ If the callback returns None (or an empty array), the mutation is marked as succ
 
 __Important Note__: by default the callback is executed __in transaction__ and, as a consequence, will (in case of exception/errors) cancel the complete mutation. If this is not the desired behaviour, the callback must explicitely detach to separate transaction (process).
 
+#### Extending mutations with signals
+Signal callbacks could use mutationExtensions JSON field to receive additional data from mutation payload. This
+feature allows to extend mutations with a new module without modifying the base mutation.
+
 #### Service signals 
 In addition, the core provides the possibility to register additional signals via 
 the `register_service_signal` decorator. Registered signals are stored in


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-717](https://openimis.atlassian.net/browse/OTC-717)

Changes:
- Added `ParsedJSONString` allowing to mimic GQL automatic camel case to snake case conversion in GQL embedded JSON fields
- Added `mutation_extensions` allowing to pass extra data to signals connected with a mutation. This allow new modules to extend existing mutations without modifying them. This field is not passed to the original mutation