### PR TITLE
OP-701 Added check permissions service helper

### DIFF
--- a/core/services/utils/serviceUtils.py
+++ b/core/services/utils/serviceUtils.py
@@ -22,6 +22,24 @@ def check_authentication(function):
     return wrapper
 
 
+def check_permissions(permissions=None):
+    def decorator(function):
+        def wrapper(self, *args, **kwargs):
+            if not self.user.has_perms(permissions):
+                return {
+                    "success": False,
+                    "message": "Permissions required",
+                    "detail": "PermissionDenied",
+                }
+            else:
+                result = function(self, *args, **kwargs)
+                return result
+
+        return wrapper
+
+    return decorator
+
+
 def model_representation(model):
     uuid_string = str(model.id)
     dict_representation = model_to_dict(model)

--- a/core/test_services.py
+++ b/core/test_services.py
@@ -228,7 +228,7 @@ class UserServicesTest(TestCase):
         officer, created = create_or_update_officer(
             user_id=None,
             data=dict(
-                username=username, last_name="Last Name O1", other_names="Other 1 2 3"
+                username=username, last_name="Last Name O1", other_names="Other 1 2 3", phone="+12345678"
             ),
             audit_user_id=999,
             connected=False,
@@ -238,6 +238,7 @@ class UserServicesTest(TestCase):
         self.assertEquals(officer.username, username)
         self.assertEquals(officer.last_name, "Last Name O1")
         self.assertEquals(officer.other_names, "Other 1 2 3")
+        self.assertEquals(officer.phone, "+12345678")
 
         deleted_officers = Officer.objects.filter(code=username).delete()
         logger.info(f"Deleted {deleted_officers} officers after test")


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-701](url[)](https://openimis.atlassian.net/browse/OTC-701)

Changes:
- Added `check_permissions`, decorator allowing checking permissions before service actions