### PR TITLE
OP-949: Query users by multiple regions

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,4 +1,3 @@
-import csv
 import json
 import logging
 import os
@@ -6,7 +5,6 @@ import sys
 import uuid
 from copy import copy
 from datetime import datetime as py_datetime, timedelta
-from typing import List, Callable
 
 from cached_property import cached_property
 from dirtyfields import DirtyFieldsMixin

--- a/core/schema.py
+++ b/core/schema.py
@@ -441,6 +441,7 @@ class Query(graphene.ObjectType):
         roles=graphene.List(of_type=graphene.Int),
         health_facility_id=graphene.Int(description="Base health facility ID (not UUID!)"),
         region_id=graphene.Int(),
+        region_ids=graphene.List(of_type=graphene.Int),
         district_id=graphene.Int(),
         municipality_id=graphene.Int(),
         village_id=graphene.Int(),
@@ -525,9 +526,9 @@ class Query(graphene.ObjectType):
         return None
 
     def resolve_users(self, info, email=None, last_name=None, other_names=None, phone=None,
-                      role_id=None, roles=None, health_facility_id=None, region_id=None, district_id=None,
-                      municipality_id=None, birth_date_from=None, birth_date_to=None, user_types=None, language=None,
-                      village_id=None, **kwargs):
+                      role_id=None, roles=None, health_facility_id=None, region_id=None,
+                      district_id=None, municipality_id=None, birth_date_from=None, birth_date_to=None,
+                      user_types=None, language=None, village_id=None, region_ids=None, **kwargs):
         if not info.context.user.has_perms(CoreConfig.gql_query_users_perms):
             raise PermissionError("Unauthorized")
 
@@ -588,8 +589,12 @@ class Query(graphene.ObjectType):
         if roles:
             user_filters.append(Q(i_user__user_roles__role_id__in=roles) &
                                 Q(i_user__user_roles__validity_to__isnull=True))
+
         if region_id:
             user_filters.append(Q(i_user__userdistrict__location__parent_id=region_id))
+        elif region_ids:
+            user_filters.append(Q(i_user__userdistrict__location__parent_id__in=region_ids))
+
         if district_id:
             user_filters.append(Q(i_user__userdistrict__location_id=district_id))
         if municipality_id:


### PR DESCRIPTION
Developed for [OP-949](https://openimis.atlassian.net/browse/OP-949)

Change extends graphql users query by additional parameter regionIds, which allows fetching users from multiple regions. 

Note: This PR doesn't provide additional security checks. We should additionally investigate whether users can retrieve data to which they are not authorized (e.g. from outside their assigned regions).