### PR TITLE
OP-1394: DRF rules package removed.

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -721,7 +721,7 @@ class Query(graphene.ObjectType):
         excluded_app = [
             "health_check.cache", "health_check", "health_check.db",
             "test_without_migrations", "test_without_migrations",
-            "rules", "graphene_django", "rest_framework", "rest_framework_rules",
+            "rules", "graphene_django", "rest_framework",
             "health_check.storage", "channels", "graphql_jwt.refresh_token.apps.RefreshTokenConfig"
         ]
         all_apps = [app for app in settings.INSTALLED_APPS if not app.startswith("django") and app not in excluded_app]


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/OP-1394
Will not work without: 
https://github.com/openimis/openimis-be_py/pull/133

Changes:
- Removed mention of django-rest-framework-rules library.