### PR TITLE
CM-68: Develop core logic for handling custom filters - BE

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ registered filters in order to obtain definition of building filters for particu
 Such kind of mechanism could be added to the particular openIMIS module in such way:
 * (not obligatory, but without this nothing is loaded into hub) implement interface from core (CustomFilterWizardInterface)
 for particular chosen object to output the definition of building filters in custom_filters.py (if no such file, simply add this file in module)
-* Declare such import statement  ```from core.custom_filters import CustomFilterRegistryPoint``` on appp.py level
+* Declare such import statement  ```from core.custom_filters import CustomFilterRegistryPoint``` on apps.py level
 * Add such lines of code in the config load part within module configuration class:
 ```
    # register custom filter

--- a/README.md
+++ b/README.md
@@ -352,6 +352,32 @@ CLASS_RULE_PARAM_VALIDATION = [
   - run_convert(instance, convert_to **argv) - execute the conversion for the instance with the first rule that provide the conversion (see get_convert_from_to). 'from_to' is deducted from instance. 
   - get_convert_from_to() - get the possible conversion, return [calc UUID, from, to]
 
+## CustomFilters
+The module gives possibility to define the way of building custom filters.
+Module consists of such classes:
+* CustomFilterRegistryPoint: class responsible for registering particular module. 
+It is called in apps.py in particular module (see below) in order to have access to way how to 
+build filter for particular objects.
+* CustomFilterWizardInterface: Interface which defines the way how implementation of custom filtering wizard look. 
+Every module has different details of implementation of delivering desired output.  
+* CustomFilterWizardStorage: Class responsible for delivering service which connect to the hub of \
+registered filters in order to obtain definition of building filters for particular object.
+
+Such kind of mechanism could be added to the particular openIMIS module in such way:
+* Declare such import statement  ```from core.custom_filters import CustomFilterRegistryPoint``` on appp.py level
+* Add such lines of code in the config load part within module configuration class:
+```
+   # register custom filter
+   CustomFilterRegistryPoint.register_custom_filters(module_name=cls.name)
+``` 
+* after such step such filter should be registered in the filter hub/storage and could 
+be accesible by calling such wizard hub service (Django shell example):
+```
+   from core.custom_filters.custom_filter_wizard_storage import CustomFilterWizardStorage
+   CustomFilterWizardStorage.build_output_how_to_build_filter('social_protection', 'BenefitPlan')
+```
+
+
 ## Configuration options (can be changed via core.ModuleConfiguration)
 * auto_provisioning_user_group: assigned user group when REMOTE_USER
   user is auto-provisioned(default: "user")

--- a/README.md
+++ b/README.md
@@ -353,27 +353,25 @@ CLASS_RULE_PARAM_VALIDATION = [
   - get_convert_from_to() - get the possible conversion, return [calc UUID, from, to]
 
 ## CustomFilters
-The module gives possibility to define the way of building custom filters.
-Module consists of such classes:
-* CustomFilterRegistryPoint: class responsible for registering particular module. 
-It is called in apps.py in particular module (see below) in order to have access to way how to 
-build filter for particular objects.
-* CustomFilterWizardInterface: Interface which defines the way how implementation of custom filtering wizard look. 
-Every module has different details of implementation of delivering desired output.  
-* CustomFilterWizardStorage: Class responsible for delivering service which connect to the hub of \
-registered filters in order to obtain definition of building filters for particular object.
+This module provides the ability to define custom filters and their construction. It includes the following classes:
+* ```CustomFilterRegistryPoint```: This class is responsible for registering a specific module. 
+It should be called in the apps.py file of the respective module (see below) to enable filter construction for specific objects.
+* ```CustomFilterWizardInterface```: This interface defines the implementation details of a custom filtering wizard. 
+Each module may have different implementations for delivering the desired output.
+* ```CustomFilterWizardStorage```: This class provides a service that connects to the registered filter hub, allowing 
+retrieval of the filter construction definition for specific objects.
 
-Such kind of mechanism could be added to the particular openIMIS module in such way:
-* (not obligatory, but without this nothing is loaded into hub) implement interface from core (CustomFilterWizardInterface)
-for particular chosen object to output the definition of building filters in custom_filters.py (if no such file, simply add this file in module)
-* Declare such import statement  ```from core.custom_filters import CustomFilterRegistryPoint``` on apps.py level
-* Add such lines of code in the config load part within module configuration class:
+To integrate this mechanism into an openIMIS module, follow these steps:
+* Implement the CustomFilterWizardInterface from the core module (if no custom_filters.py file exists, create one in the module) 
+to output the filter construction definition for the chosen object.
+* In the apps.py file of the module, add the following import statement: ```from core.custom_filters import CustomFilterRegistryPoint```.
+* Within the module's configuration class, in the configuration loading section, include the following lines of code:
 ```
    # register custom filter
    CustomFilterRegistryPoint.register_custom_filters(module_name=cls.name)
 ``` 
-* after such step such filter should be registered in the filter hub/storage and could 
-be accesible by calling such wizard hub service (Django shell example):
+* After completing the above steps, the filter will be registered in the filter hub/storage and can be accessed 
+by invoking the wizard hub service. Here's an example using the Django shell:
 ```
    from core.custom_filters.custom_filter_wizard_storage import CustomFilterWizardStorage
    CustomFilterWizardStorage.build_output_how_to_build_filter('social_protection', 'BenefitPlan')

--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ Every module has different details of implementation of delivering desired outpu
 registered filters in order to obtain definition of building filters for particular object.
 
 Such kind of mechanism could be added to the particular openIMIS module in such way:
+* (not obligatory, but without this nothing is loaded into hub) implement interface from core (CustomFilterWizardInterface)
+for particular chosen object to output the definition of building filters in custom_filters.py (if no such file, simply add this file in module)
 * Declare such import statement  ```from core.custom_filters import CustomFilterRegistryPoint``` on appp.py level
 * Add such lines of code in the config load part within module configuration class:
 ```

--- a/README.md
+++ b/README.md
@@ -368,13 +368,17 @@ to output the filter construction definition for the chosen object.
 * Within the module's configuration class, in the configuration loading section, include the following lines of code:
 ```
    # register custom filter
-   CustomFilterRegistryPoint.register_custom_filters(module_name=cls.name)
+   from social_protection.custom_filters import BenefitPlanCustomFilterWizard, BeneficiaryCustomFilterWizard
+   CustomFilterRegistryPoint.register_custom_filters(
+       module_name=cls.name,
+       custom_filter_class_list=[BenefitPlanCustomFilterWizard, BeneficiaryCustomFilterWizard]
+   )
 ``` 
 * After completing the above steps, the filter will be registered in the filter hub/storage and can be accessed 
 by invoking the wizard hub service. Here's an example using the Django shell:
 ```
    from core.custom_filters.custom_filter_wizard_storage import CustomFilterWizardStorage
-   CustomFilterWizardStorage.build_output_how_to_build_filter('social_protection', 'BenefitPlan')
+   CustomFilterWizardStorage.build_output_how_to_build_filter('social_protection', 'Beneficiary')
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -354,18 +354,17 @@ CLASS_RULE_PARAM_VALIDATION = [
 
 ## CustomFilters
 This module provides the ability to define custom filters and their construction. It includes the following classes:
-* ```CustomFilterRegistryPoint```: This class is responsible for registering a specific module. 
-It should be called in the apps.py file of the respective module (see below) to enable filter construction for specific objects.
-* ```CustomFilterWizardInterface```: This interface defines the implementation details of a custom filtering wizard. 
-Each module may have different implementations for delivering the desired output.
+* ```CustomFilterRegistryPoint```: This class is responsible for registering filters from a specific module. 
+* ```CustomFilterWizardInterface```: This interface defines the implementation details of a custom filtering wizard.
+It should be called in the apps.py file of the respective module (see example below) to enable filter construction for specific objects.
 * ```CustomFilterWizardStorage```: This class provides a service that connects to the registered filter hub, allowing 
 retrieval of the filter construction definition for specific objects.
 
 To integrate this mechanism into an openIMIS module, follow these steps:
-* Implement the CustomFilterWizardInterface from the core module (if no custom_filters.py file exists, create one in the module) 
+* Implement the CustomFilterWizardInterface from the core module
 to output the filter construction definition for the chosen object.
 * In the apps.py file of the module, add the following import statement: ```from core.custom_filters import CustomFilterRegistryPoint```.
-* Within the module's configuration class, in the configuration loading section, include the following lines of code:
+* Invoke such example code somewhere in ready() method in apps.py file:
 ```
    # register custom filter
    from social_protection.custom_filters import BenefitPlanCustomFilterWizard, BeneficiaryCustomFilterWizard

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,4 +1,3 @@
-import inspect
 import sys
 import os
 import importlib

--- a/core/apps.py
+++ b/core/apps.py
@@ -5,7 +5,6 @@ import logging
 from django.apps import AppConfig
 from django.conf import settings
 
-from core.custom_filters import CustomFilterRegistryPoint
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +174,6 @@ class CoreConfig(AppConfig):
         self._configure_graphql(cfg)
         self._configure_currency(cfg)
         self._configure_permissions(cfg)
-        CustomFilterRegistryPoint.register_custom_filters()
 
         self.password_reset_template = cfg["password_reset_template"]
 

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,9 +1,12 @@
+import inspect
 import sys
 import os
 import importlib
 import logging
 from django.apps import AppConfig
 from django.conf import settings
+
+from core.custom_filters import CustomFilterRegistryPoint
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +176,7 @@ class CoreConfig(AppConfig):
         self._configure_graphql(cfg)
         self._configure_currency(cfg)
         self._configure_permissions(cfg)
+        CustomFilterRegistryPoint.register_custom_filters()
 
         self.password_reset_template = cfg["password_reset_template"]
 

--- a/core/custom_filters/__init__.py
+++ b/core/custom_filters/__init__.py
@@ -1,0 +1,2 @@
+from core.custom_filters.custom_filter_wizard_interface import CustomFilterWizardInterface
+from core.custom_filters.custom_filter_registry_point import CustomFilterRegistryPoint

--- a/core/custom_filters/__init__.py
+++ b/core/custom_filters/__init__.py
@@ -1,2 +1,3 @@
 from core.custom_filters.custom_filter_wizard_interface import CustomFilterWizardInterface
 from core.custom_filters.custom_filter_registry_point import CustomFilterRegistryPoint
+from core.custom_filters.custom_filter_wizard_storage import CustomFilterWizardStorage

--- a/core/custom_filters/custom_filter_registry_point.py
+++ b/core/custom_filters/custom_filter_registry_point.py
@@ -11,23 +11,24 @@ logger = logging.getLogger(__name__)
 
 class CustomFilterRegistryPoint:
     """
-        Class reponsible for delivering methods to handle registering custom filters.
-        REGISTERED_CUSTOM_FILTER_WIZARDS - dictionary responsible for collecting registered implementation of custom
-        filter wizards. The example of structure is:
-          {
-              'policy': [],
-              'social_protection': [{
+    Class responsible for handling the registration of custom filters.
+
+    REGISTERED_CUSTOM_FILTER_WIZARDS:
+    A dictionary that collects registered implementations of custom filter wizards.
+    The structure of the dictionary is as follows:
+
+    {
+        'policy': [],
+        'social_protection': [
+            {
                 'class_reference': <class 'social_protection.custom_filters.BeneficiaryCustomFilterCreator'>,
                 'module': 'social_protection'
-            }]
-          }
-        __CLASS_SUBSTRING_NAME - constant responsible for checking if particual module contains
-        implementation of custom filter. The fixed value is 'CustomFilterWizard'.
+            }
+        ]
+    }
     """
 
     REGISTERED_CUSTOM_FILTER_WIZARDS = {}
-
-    __CLASS_SUBSTRING_NAME = "CustomFilterWizard"
 
     @classmethod
     def register_custom_filters(
@@ -36,12 +37,17 @@ class CustomFilterRegistryPoint:
         custom_filter_class_list: List[CustomFilterWizardInterface]
     ) -> None:
         """
-            Process registering the custom filters wizards for
-            particular module registered in openIMIS applicatiom
+            Register custom filter wizards for a specific module in the openIMIS application.
 
-            :param module_name: the name of module that is installed in openIMIS.
-            :param custom_filter_class_list: list of objects that need to be registered as a custom filter in hub.
-            :return: None (void method)
+            This method registers the provided list of objects as custom filters in the hub,
+            for the specified module in the openIMIS application.
+
+            Args:
+                module_name (str): The name of the module installed in openIMIS.
+                custom_filter_class_list (list): A list of objects representing the custom filter implementations.
+
+            Returns:
+                None: This method does not return anything.
         """
         logger.debug(F"registering custom filter in {module_name} module")
         for custom_filter_class in custom_filter_class_list:
@@ -55,15 +61,19 @@ class CustomFilterRegistryPoint:
         custom_filter_class: CustomFilterWizardInterface
     ) -> None:
         """
-            Gathering the presence of custom filter wizard class in particular module
-            There is additional check whether there is such kind of class within custom_filter.py
-            file. If yes then such filter wizard reference is added to the list of registered wizards
-            within openIMIS application
+            Gather the presence of a custom filter wizard class in a specific module and register it.
 
-            :param module_name: the name of module that is installed in openIMIS
-             where it is checked if there is filter wizard implementation.
-            :param custom_filter_class: object that need to be registered as a custom filter in hub
-            :return: None (void method)
+            This method checks the presence of a custom filter wizard class within the module.
+            If the class exists, the filter wizard reference is added to the list of registered wizards
+            within the openIMIS application.
+
+            Args:
+                module_name (str): The name of the module from which the custom filter objects originate.
+                custom_filter_class: An object that needs to be registered as a custom filter in the hub,
+                                     grouped under the specific module.
+
+            Returns:
+                None: This is a void method.
         """
         if module_name not in cls.REGISTERED_CUSTOM_FILTER_WIZARDS:
             cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"] = []

--- a/core/custom_filters/custom_filter_registry_point.py
+++ b/core/custom_filters/custom_filter_registry_point.py
@@ -37,17 +37,18 @@ class CustomFilterRegistryPoint:
         custom_filter_class_list: List[CustomFilterWizardInterface]
     ) -> None:
         """
-            Register custom filter wizards for a specific module in the openIMIS application.
+        Register custom filter wizards for a specific module in the openIMIS application.
 
-            This method registers the provided list of objects as custom filters in the hub,
-            for the specified module in the openIMIS application.
+        This method registers the provided list of objects as custom filters in the hub,
+        for the specified module in the openIMIS application.
 
-            Args:
-                module_name (str): The name of the module installed in openIMIS.
-                custom_filter_class_list (list): A list of objects representing the custom filter implementations.
+        :param module_name: The name of the module installed in openIMIS.
+        :type module_name: str
+        :param custom_filter_class_list: A list of objects representing the custom filter implementations.
+        :type custom_filter_class_list: list
 
-            Returns:
-                None: This method does not return anything.
+        :return: This method does not return anything.
+        :rtype: None
         """
         logger.debug(F"registering custom filter in {module_name} module")
         for custom_filter_class in custom_filter_class_list:
@@ -60,21 +61,6 @@ class CustomFilterRegistryPoint:
         module_name: str,
         custom_filter_class: CustomFilterWizardInterface
     ) -> None:
-        """
-            Gather the presence of a custom filter wizard class in a specific module and register it.
-
-            This method checks the presence of a custom filter wizard class within the module.
-            If the class exists, the filter wizard reference is added to the list of registered wizards
-            within the openIMIS application.
-
-            Args:
-                module_name (str): The name of the module from which the custom filter objects originate.
-                custom_filter_class: An object that needs to be registered as a custom filter in the hub,
-                                     grouped under the specific module.
-
-            Returns:
-                None: This is a void method.
-        """
         if module_name not in cls.REGISTERED_CUSTOM_FILTER_WIZARDS:
             cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"] = []
         cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"].append({

--- a/core/custom_filters/custom_filter_registry_point.py
+++ b/core/custom_filters/custom_filter_registry_point.py
@@ -17,7 +17,6 @@ class CustomFilterRegistryPoint:
           {
               'policy': [],
               'social_protection': [{
-                'class_name': 'BeneficiaryCustomFilterCreator',
                 'class_reference': <class 'social_protection.custom_filters.BeneficiaryCustomFilterCreator'>,
                 'module': 'social_protection'
             }]
@@ -50,7 +49,11 @@ class CustomFilterRegistryPoint:
             logger.debug(F"Such module {module_name} provides custom filters wizards")
 
     @classmethod
-    def __collect_custom_filter_wizards(cls, module_name: str, custom_filter_class: CustomFilterWizardInterface) -> None:
+    def __collect_custom_filter_wizards(
+        cls,
+        module_name: str,
+        custom_filter_class: CustomFilterWizardInterface
+    ) -> None:
         """
             Gathering the presence of custom filter wizard class in particular module
             There is additional check whether there is such kind of class within custom_filter.py
@@ -62,7 +65,8 @@ class CustomFilterRegistryPoint:
             :param custom_filter_class: object that need to be registered as a custom filter in hub
             :return: None (void method)
         """
-        cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"] = []
+        if module_name not in cls.REGISTERED_CUSTOM_FILTER_WIZARDS:
+            cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"] = []
         cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"].append({
             "class_reference": custom_filter_class,
             "module": module_name

--- a/core/custom_filters/custom_filter_registry_point.py
+++ b/core/custom_filters/custom_filter_registry_point.py
@@ -1,0 +1,103 @@
+import inspect
+import importlib
+import importlib.util
+import logging
+import os
+
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class CustomFilterRegistryPoint:
+    """
+        Class reponsible for delivering methods to handle registering custom filters.
+        REGISTERED_CUSTOM_FILTER_WIZARDS - static dict responsible for collecting registered implementation of custom
+        filter wizards. The example of structure is:
+          {
+              'policy': [],
+              'social_protection': [{
+                'class_name': 'BeneficiaryCustomFilterCreator',
+                'class_reference': <class 'social_protection.custom_filters.BeneficiaryCustomFilterCreator'>,
+                'module': 'social_protection'
+            }]
+          }
+        __CLASS_SUBSTRING_NAME - private static constant responsible for checking if particual module contains
+        implementation of custom filter. The fixed value is 'CustomFilterWizard'.
+    """
+
+    REGISTERED_CUSTOM_FILTER_WIZARDS = {}
+
+    __CLASS_SUBSTRING_NAME = "CustomFilterWizard"
+
+    @classmethod
+    def register_custom_filters(cls) -> None:
+        """
+            Process registering the custom filters wizards within application
+            for all modules presented in openIMIS applicatiom
+
+            :return: None (void method).
+        """
+        logger.debug("registering custom filters")
+        for app in settings.OPENIMIS_APPS:
+            cls._register_app_custom_filters(app)
+
+    @classmethod
+    def _register_app_custom_filters(cls, module_name: str) -> None:
+        """
+            Process registering the custom filters wizards for
+            particular module registered in openIMIS applicatiom
+
+            :param module_name: the name of module that is installed in openIMIS.
+            :return: None (void method).
+        """
+        if cls.__check_module_file(module_name, 'custom_filters.py'):
+            cls.__collect_custom_filter_wizards(module_name)
+            logger.debug(F"Such module {module_name} provides custom filters wizards")
+        else:
+            logger.debug(f"Such module {module_name} doesn't provide any custom filters wizards")
+
+    @classmethod
+    def __check_module_file(cls, module_name: str, file_name: str) -> bool:
+        """
+            Verify if module contains particular file responsible for
+            registering custom filter wizard
+
+            :param module_name: the name of module that is installed in openIMIS
+             where we need to check the file presence.
+            :param file_name: the name of file that we need to check if this file
+             is included in that particular module.
+            :return: bool.
+        """
+        module_path = __import__(module_name).__file__
+        file_path = os.path.join(os.path.dirname(module_path), file_name)
+        return os.path.isfile(file_path)
+
+    @classmethod
+    def __collect_custom_filter_wizards(cls, module_name: str) -> None:
+        """
+            Gathering the presence of custom filter wizard class in particular module
+            There is additional check whether there is such kind of class within custom_filter.py
+            file. If yes then such filter wizard reference is added to the list of registered wizards
+            within openIMIS application
+
+            :param module_name: the name of module that is installed in openIMIS
+             where it is checked if there is filter wizard implementation.
+            :return: None (void method).
+        """
+        cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"] = []
+        for class_name, class_object in inspect.getmembers(
+            importlib.import_module(f"{module_name}.custom_filters"),
+            inspect.isclass
+        ):
+            source_of_wizard_class = class_object.__module__.split('.')[0]
+            if (
+                module_name == source_of_wizard_class and
+                cls.__CLASS_SUBSTRING_NAME in class_name
+            ):
+                cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"].append({
+                    "class_name": class_name,
+                    "class_reference": class_object,
+                    "module": module_name
+                })

--- a/core/custom_filters/custom_filter_registry_point.py
+++ b/core/custom_filters/custom_filter_registry_point.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class CustomFilterRegistryPoint:
     """
         Class reponsible for delivering methods to handle registering custom filters.
-        REGISTERED_CUSTOM_FILTER_WIZARDS - static dict responsible for collecting registered implementation of custom
+        REGISTERED_CUSTOM_FILTER_WIZARDS - dictionary responsible for collecting registered implementation of custom
         filter wizards. The example of structure is:
           {
               'policy': [],
@@ -23,7 +23,7 @@ class CustomFilterRegistryPoint:
                 'module': 'social_protection'
             }]
           }
-        __CLASS_SUBSTRING_NAME - private static constant responsible for checking if particual module contains
+        __CLASS_SUBSTRING_NAME - constant responsible for checking if particual module contains
         implementation of custom filter. The fixed value is 'CustomFilterWizard'.
     """
 
@@ -37,7 +37,7 @@ class CustomFilterRegistryPoint:
             Process registering the custom filters wizards within application
             for all modules presented in openIMIS applicatiom
 
-            :return: None (void method).
+            :return: None (void method)
         """
         logger.debug("registering custom filters")
         for app in settings.OPENIMIS_APPS:
@@ -50,7 +50,7 @@ class CustomFilterRegistryPoint:
             particular module registered in openIMIS applicatiom
 
             :param module_name: the name of module that is installed in openIMIS.
-            :return: None (void method).
+            :return: None (void method)
         """
         if cls.__check_module_file(module_name, 'custom_filters.py'):
             cls.__collect_custom_filter_wizards(module_name)
@@ -68,7 +68,7 @@ class CustomFilterRegistryPoint:
              where we need to check the file presence.
             :param file_name: the name of file that we need to check if this file
              is included in that particular module.
-            :return: bool.
+            :return: bool
         """
         module_path = __import__(module_name).__file__
         file_path = os.path.join(os.path.dirname(module_path), file_name)
@@ -84,7 +84,7 @@ class CustomFilterRegistryPoint:
 
             :param module_name: the name of module that is installed in openIMIS
              where it is checked if there is filter wizard implementation.
-            :return: None (void method).
+            :return: None (void method)
         """
         cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"] = []
         for class_name, class_object in inspect.getmembers(

--- a/core/custom_filters/custom_filter_registry_point.py
+++ b/core/custom_filters/custom_filter_registry_point.py
@@ -1,8 +1,9 @@
-import inspect
-import importlib
-import importlib.util
 import logging
 import os
+
+from typing import List
+
+from core.custom_filters import CustomFilterWizardInterface
 
 
 logger = logging.getLogger(__name__)
@@ -30,46 +31,26 @@ class CustomFilterRegistryPoint:
     __CLASS_SUBSTRING_NAME = "CustomFilterWizard"
 
     @classmethod
-    def register_custom_filters(cls, module_name: str) -> None:
+    def register_custom_filters(
+        cls,
+        module_name: str,
+        custom_filter_class_list: List[CustomFilterWizardInterface]
+    ) -> None:
         """
             Process registering the custom filters wizards for
             particular module registered in openIMIS applicatiom
 
             :param module_name: the name of module that is installed in openIMIS.
+            :param custom_filter_class_list: list of objects that need to be registered as a custom filter in hub.
             :return: None (void method)
         """
         logger.debug(F"registering custom filter in {module_name} module")
-        if cls.__check_module_file(module_name, 'custom_filters.py'):
-            cls.__collect_custom_filter_wizards(module_name)
+        for custom_filter_class in custom_filter_class_list:
+            cls.__collect_custom_filter_wizards(module_name, custom_filter_class)
             logger.debug(F"Such module {module_name} provides custom filters wizards")
-        else:
-            logger.debug(f"Such module {module_name} doesn't provide any custom filters wizards")
 
     @classmethod
-    def __check_module_file(cls, module_name: str, file_name: str) -> bool:
-        """
-            Verify if module contains particular file responsible for
-            registering custom filter wizard
-
-            :param module_name: the name of module that is installed in openIMIS
-             where we need to check the file presence.
-            :param file_name: the name of file that we need to check if this file
-             is included in that particular module.
-            :return: bool
-        """
-        try:
-            module_path = __import__(module_name).__file__
-            file_path = os.path.join(os.path.dirname(module_path), file_name)
-            return os.path.isfile(file_path)
-        except ModuleNotFoundError:
-            logger.debug(f"{module_name} does not exist within openIMIS application")
-            return False
-        except Exception as exc:
-            logger.debug(f"{module_name}: unknown exception occurred during registering custom filter: {exc}")
-            return False
-
-    @classmethod
-    def __collect_custom_filter_wizards(cls, module_name: str) -> None:
+    def __collect_custom_filter_wizards(cls, module_name: str, custom_filter_class: CustomFilterWizardInterface) -> None:
         """
             Gathering the presence of custom filter wizard class in particular module
             There is additional check whether there is such kind of class within custom_filter.py
@@ -78,20 +59,11 @@ class CustomFilterRegistryPoint:
 
             :param module_name: the name of module that is installed in openIMIS
              where it is checked if there is filter wizard implementation.
+            :param custom_filter_class: object that need to be registered as a custom filter in hub
             :return: None (void method)
         """
         cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"] = []
-        for class_name, class_object in inspect.getmembers(
-            importlib.import_module(f"{module_name}.custom_filters"),
-            inspect.isclass
-        ):
-            source_of_wizard_class = class_object.__module__.split('.')[0]
-            if (
-                module_name == source_of_wizard_class and
-                cls.__CLASS_SUBSTRING_NAME in class_name
-            ):
-                cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"].append({
-                    "class_name": class_name,
-                    "class_reference": class_object,
-                    "module": module_name
-                })
+        cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"].append({
+            "class_reference": custom_filter_class,
+            "module": module_name
+        })

--- a/core/custom_filters/custom_filter_registry_point.py
+++ b/core/custom_filters/custom_filter_registry_point.py
@@ -65,7 +65,7 @@ class CustomFilterRegistryPoint:
             logger.debug(f"{module_name} does not exist within openIMIS application")
             return False
         except Exception as exc:
-            logger.debug(f"{module_name}: unknown exception occurred during registering scheduled tasks: {exc}")
+            logger.debug(f"{module_name}: unknown exception occurred during registering custom filter: {exc}")
             return False
 
     @classmethod

--- a/core/custom_filters/custom_filter_wizard_interface.py
+++ b/core/custom_filters/custom_filter_wizard_interface.py
@@ -4,9 +4,21 @@ from typing import List
 
 class CustomFilterWizardInterface:
     def get_type_of_object(self) -> str:
-        """get the type of object - the actor of such filtering action"""
+        """
+            Get the type of object from which we want to define
+            specific way of building filters
+
+            :return: str
+        """
         pass
 
     def load_definition(self, tuple_type: type) -> List[namedtuple]:
-        """Load the definition of the object in order to retrieve how to create filters"""
+        """Load the definition how to create filters"""
+        """
+            Load the definition how to create filters
+
+            :param tuple_type: the type of tuple
+             
+            :return: List[namedtuple]
+        """
         pass

--- a/core/custom_filters/custom_filter_wizard_interface.py
+++ b/core/custom_filters/custom_filter_wizard_interface.py
@@ -1,0 +1,11 @@
+from typing import List, Tuple
+
+
+class CustomFilterWizardInterface:
+    def get_type_of_object(self) -> type:
+        """get the type of object - the actor of such filtering action"""
+        pass
+
+    def load_definition(self) -> List[Tuple]:
+        """Load the definition of the object in order to retrieve how to create filters"""
+        pass

--- a/core/custom_filters/custom_filter_wizard_interface.py
+++ b/core/custom_filters/custom_filter_wizard_interface.py
@@ -12,7 +12,7 @@ class CustomFilterWizardInterface:
         """
         pass
 
-    def load_definition(self, tuple_type: type) -> List[namedtuple]:
+    def load_definition(self, tuple_type: type, **kwargs) -> List[namedtuple]:
         """
             Load the definition how to create filters. The output is simply the list
             of named tuple (from collections package). Such named tuple is built in such way:

--- a/core/custom_filters/custom_filter_wizard_interface.py
+++ b/core/custom_filters/custom_filter_wizard_interface.py
@@ -13,9 +13,11 @@ class CustomFilterWizardInterface:
         pass
 
     def load_definition(self, tuple_type: type) -> List[namedtuple]:
-        """Load the definition how to create filters"""
         """
-            Load the definition how to create filters
+            Load the definition how to create filters. The output is simply the list
+            of named tuple (from collections package). Such named tuple is built in such way:
+            <Type>(field=<str>, filter=<str>, value=<str>) for example:
+            BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
 
             :param tuple_type: the type of tuple
              

--- a/core/custom_filters/custom_filter_wizard_interface.py
+++ b/core/custom_filters/custom_filter_wizard_interface.py
@@ -3,29 +3,30 @@ from typing import List
 
 
 class CustomFilterWizardInterface:
+
     def get_type_of_object(self) -> str:
         """
-            Get the type of object for which we want to define a specific way of building filters.
+        Get the type of object for which we want to define a specific way of building filters.
 
-            Returns:
-                str: The type of the object.
+        :return: The type of the object.
+        :rtype: str
         """
         pass
 
     def load_definition(self, tuple_type: type, **kwargs) -> List[namedtuple]:
         """
-            Load the definition of how to create filters.
+        Load the definition of how to create filters.
 
-            This method retrieves the definition of how to create filters and returns it as a list of named tuples.
-            Each named tuple is built with the provided `tuple_type` and has the fields `field`, `filter`, and `value`.
+        This method retrieves the definition of how to create filters and returns it as a list of named tuples.
+        Each named tuple is built with the provided `tuple_type` and has the fields `field`, `filter`, and `value`.
 
-            Example named tuple: <Type>(field=<str>, filter=<str>, value=<str>)
-            Example usage: BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
+        Example named tuple: <Type>(field=<str>, filter=<str>, value=<str>)
+        Example usage: BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
 
-            Args:
-                tuple_type (type): The type of the named tuple.
+        :param tuple_type: The type of the named tuple.
+        :type tuple_type: type
 
-            Returns:
-                List[namedtuple]: A list of named tuples representing the definition of how to create filters.
+        :return: A list of named tuples representing the definition of how to create filters.
+        :rtype: List[namedtuple]
         """
         pass

--- a/core/custom_filters/custom_filter_wizard_interface.py
+++ b/core/custom_filters/custom_filter_wizard_interface.py
@@ -5,22 +5,27 @@ from typing import List
 class CustomFilterWizardInterface:
     def get_type_of_object(self) -> str:
         """
-            Get the type of object from which we want to define
-            specific way of building filters
+            Get the type of object for which we want to define a specific way of building filters.
 
-            :return: str
+            Returns:
+                str: The type of the object.
         """
         pass
 
     def load_definition(self, tuple_type: type, **kwargs) -> List[namedtuple]:
         """
-            Load the definition how to create filters. The output is simply the list
-            of named tuple (from collections package). Such named tuple is built in such way:
-            <Type>(field=<str>, filter=<str>, value=<str>) for example:
-            BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
+            Load the definition of how to create filters.
 
-            :param tuple_type: the type of tuple
-             
-            :return: List[namedtuple]
+            This method retrieves the definition of how to create filters and returns it as a list of named tuples.
+            Each named tuple is built with the provided `tuple_type` and has the fields `field`, `filter`, and `value`.
+
+            Example named tuple: <Type>(field=<str>, filter=<str>, value=<str>)
+            Example usage: BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
+
+            Args:
+                tuple_type (type): The type of the named tuple.
+
+            Returns:
+                List[namedtuple]: A list of named tuples representing the definition of how to create filters.
         """
         pass

--- a/core/custom_filters/custom_filter_wizard_interface.py
+++ b/core/custom_filters/custom_filter_wizard_interface.py
@@ -1,11 +1,12 @@
-from typing import List, Tuple
+from collections import namedtuple
+from typing import List
 
 
 class CustomFilterWizardInterface:
-    def get_type_of_object(self) -> type:
+    def get_type_of_object(self) -> str:
         """get the type of object - the actor of such filtering action"""
         pass
 
-    def load_definition(self) -> List[Tuple]:
+    def load_definition(self, tuple_type: type) -> List[namedtuple]:
         """Load the definition of the object in order to retrieve how to create filters"""
         pass

--- a/core/custom_filters/custom_filter_wizard_storage.py
+++ b/core/custom_filters/custom_filter_wizard_storage.py
@@ -1,0 +1,54 @@
+import logging
+
+from collections import namedtuple
+from typing import List
+
+from core.custom_filters.custom_filter_registry_point import CustomFilterRegistryPoint
+from core.custom_filters import CustomFilterWizardInterface
+
+
+logger = logging.getLogger(__name__)
+
+
+class CustomFilterWizardStorage:
+    """
+        Class responsible for keeping information how to create filter based on the context of
+        particular wizard creator. Such hub provides the information about the way how to build
+        filters for chosen field.
+    """
+
+    __KEY_FOR_OBTAINING_CLASS = 'class_reference'
+    __FIELD = 'field'
+    __FILTER = 'filter'
+    __VALUE = 'value'
+
+    @classmethod
+    def build_output_for_frontend(cls) -> List[namedtuple]:
+        output_of_possible_filters = []
+        registered_filter_wizards = CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS
+        for key in registered_filter_wizards:
+            for registered_filter_wizard in registered_filter_wizards[key]:
+                if cls.__KEY_FOR_OBTAINING_CLASS:
+                    wizard_filter_class = cls.__create_instance_of_wizard_class(registered_filter_wizard)
+                    cls.__run_load_definition_object_in_wizard(wizard_filter_class, output_of_possible_filters)
+                    logger.debug('Definiton has been loaded into output')
+                else:
+                    logger.debug('There is no information about class representation for wizard filters')
+        return output_of_possible_filters
+
+    @classmethod
+    def __run_load_definition_object_in_wizard(
+        cls,
+        wizard_filter_class: CustomFilterWizardInterface,
+        output_of_possible_filters: List[namedtuple]
+    ) -> None:
+        wizard_filter_tuple_type = namedtuple(
+            wizard_filter_class.get_type_of_object(),
+            [cls.__FIELD, cls.__FILTER, cls.__VALUE]
+        )
+        tuple_result = wizard_filter_class.load_definition(wizard_filter_tuple_type)
+        output_of_possible_filters.append(tuple_result)
+
+    @classmethod
+    def __create_instance_of_wizard_class(cls, registered_filter_wizard) -> CustomFilterWizardInterface:
+        return registered_filter_wizard[cls.__KEY_FOR_OBTAINING_CLASS]()

--- a/core/custom_filters/custom_filter_wizard_storage.py
+++ b/core/custom_filters/custom_filter_wizard_storage.py
@@ -15,6 +15,11 @@ class CustomFilterWizardStorage:
         Class responsible for keeping information how to create filter based on the context of
         particular wizard creator. Such hub provides the information about the way how to build
         filters for chosen field.
+        __KEY_FOR_OBTAINING_CLASS - constant which indicates which element from registry points should be
+        considered in order to retrieve information about registered CustomFilterWizard class
+        __FIELD - constant which identifies the first value of final output (tuple) how to build filter
+        __FILTER - constant which identifies the second value of final output (tuple) how to build filter
+        __VALUE - constant which identifies the third value of final output (tuple) how to build filter
     """
 
     __KEY_FOR_OBTAINING_CLASS = 'class_reference'
@@ -23,17 +28,30 @@ class CustomFilterWizardStorage:
     __VALUE = 'value'
 
     @classmethod
-    def build_output_for_frontend(cls) -> List[namedtuple]:
+    def build_output_how_to_build_filter(cls, module_name: str, object_type: str) -> List[namedtuple]:
+        """
+            Building the final outcome how to build filter based on the information provided
+            by registered custom filter wizard based on the provided module name and type of object.
+            The output is simply the list of named tuple (from collections package). Such named
+            tuple is built in such way:
+            <Type>(field=<str>, filter=<str>, value=<str>) for example:
+            BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
+
+            :param module_name: the name of module that is installed in openIMIS which is necessary
+             to retrieve information about possible ways of building filters for that specific module
+            :param object_type: the name of object type that is needed to retrieve information
+             about possible ways of building filters for that specific type
+
+            :return: List[namedtupe]
+        """
         output_of_possible_filters = []
         registered_filter_wizards = CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS
-        for key in registered_filter_wizards:
-            for registered_filter_wizard in registered_filter_wizards[key]:
-                if cls.__KEY_FOR_OBTAINING_CLASS:
+        if module_name in registered_filter_wizards:
+            for registered_filter_wizard in registered_filter_wizards[module_name]:
+                if cls.__KEY_FOR_OBTAINING_CLASS in registered_filter_wizard:
                     wizard_filter_class = cls.__create_instance_of_wizard_class(registered_filter_wizard)
-                    cls.__run_load_definition_object_in_wizard(wizard_filter_class, output_of_possible_filters)
-                    logger.debug('Definiton has been loaded into output')
-                else:
-                    logger.debug('There is no information about class representation for wizard filters')
+                    if cls.__check_object_type(wizard_filter_class, object_type):
+                        cls.__run_load_definition_object_in_wizard(wizard_filter_class, output_of_possible_filters)
         return output_of_possible_filters
 
     @classmethod
@@ -42,13 +60,49 @@ class CustomFilterWizardStorage:
         wizard_filter_class: CustomFilterWizardInterface,
         output_of_possible_filters: List[namedtuple]
     ) -> None:
+        """
+            Method responsible for running loading definition of possible ways of
+            building filters in the specific provided custom filter wizard class.
+
+            :param wizard_filter_class: dictionary which cointains the information
+             about particular registered CustomWizardClass where there is implemented method
+             how to load such definitions of possbile way of building filters
+            :param output_of_possible_filters: the list that contains the definitions
+             how to build filters. In that context is appended to such list if there are any
+             specific definitions of filters for particular field.
+
+            :return: None (void method)
+        """
         wizard_filter_tuple_type = namedtuple(
             wizard_filter_class.get_type_of_object(),
             [cls.__FIELD, cls.__FILTER, cls.__VALUE]
         )
-        tuple_result = wizard_filter_class.load_definition(wizard_filter_tuple_type)
-        output_of_possible_filters.append(tuple_result)
+        tuple_list_result = wizard_filter_class.load_definition(wizard_filter_tuple_type)
+        output_of_possible_filters.extend(tuple_list_result)
 
     @classmethod
-    def __create_instance_of_wizard_class(cls, registered_filter_wizard) -> CustomFilterWizardInterface:
+    def __create_instance_of_wizard_class(cls, registered_filter_wizard: dict) -> CustomFilterWizardInterface:
+        """
+            Method responsible to create instance of custom filter wizard class
+
+            :param registered_filter_wizard: dictionary which cointains the information
+             about particular registered CustomWizardClass
+
+            :return: bool
+        """
         return registered_filter_wizard[cls.__KEY_FOR_OBTAINING_CLASS]()
+
+    @classmethod
+    def __check_object_type(cls, wizard_filter_class: CustomFilterWizardInterface, object_type: str) -> bool:
+        """
+            Verify if such object is matched to the object definied in instance of class responsible for
+            implementing wizard interface in given object type
+
+            :param wizard_filter_class: the instance of class responsible for implementation of
+             CustomFilterWizardInterface in given object type
+            :param object_type: string representation of object class that take a part in
+             filtering customization.
+
+            :return: bool
+        """
+        return object_type == wizard_filter_class.get_type_of_object()

--- a/core/custom_filters/custom_filter_wizard_storage.py
+++ b/core/custom_filters/custom_filter_wizard_storage.py
@@ -12,14 +12,16 @@ logger = logging.getLogger(__name__)
 
 class CustomFilterWizardStorage:
     """
-        Class responsible for keeping information how to create filter based on the context of
-        particular wizard creator. Such hub provides the information about the way how to build
-        filters for chosen field.
-        __KEY_FOR_OBTAINING_CLASS - constant which indicates which element from registry points should be
-        considered in order to retrieve information about registered CustomFilterWizard class
-        __FIELD - constant which identifies the first value of final output (tuple) how to build filter
-        __FILTER - constant which identifies the second value of final output (tuple) how to build filter
-        __VALUE - constant which identifies the third value of final output (tuple) how to build filter
+        Class responsible for storing information on how to create filters based on the context of
+        a particular wizard creator. This hub provides information about the method for building
+        filters for a chosen field in specific object.
+
+        Constants:
+            __KEY_FOR_OBTAINING_CLASS: Indicates which element from the registry points should be
+                                       considered to retrieve information about the registered CustomFilterWizard class.
+            __FIELD: Identifies the first value of the final output tuple for building filters.
+            __FILTER: Identifies the second value of the final output tuple for building filters.
+            __VALUE: Identifies the third value of the final output tuple for building filters.
     """
 
     __KEY_FOR_OBTAINING_CLASS = 'class_reference'
@@ -30,19 +32,21 @@ class CustomFilterWizardStorage:
     @classmethod
     def build_output_how_to_build_filter(cls, module_name: str, object_type: str, **kwargs) -> List[namedtuple]:
         """
-            Building the final outcome how to build filter based on the information provided
-            by registered custom filter wizard based on the provided module name and type of object.
-            The output is simply the list of named tuple (from collections package). Such named
-            tuple is built in such way:
-            <Type>(field=<str>, filter=<str>, value=<str>) for example:
-            BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
+            Build the final outcome for creating a filter based on the information provided by
+            a registered custom filter wizard for the specified module name and object type.
 
-            :param module_name: the name of module that is installed in openIMIS which is necessary
-             to retrieve information about possible ways of building filters for that specific module
-            :param object_type: the name of object type that is needed to retrieve information
-             about possible ways of building filters for that specific type
+            The output is a list of named tuples (from the collections package). Each named tuple is built
+            in the following format: <Type>(field=<str>, filter=<str>, value=<str>)
 
-            :return: List[namedtupe]
+            Example named tuple: BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
+
+            Args:
+                module_name (str): The name of the module installed in openIMIS, required to retrieve information
+                                   about the possible ways of building filters for that specific module.
+                object_type (str): The name of the object type for which the filter building information is needed.
+
+            Returns:
+                List[namedtuple]: A list of named tuples representing the final outcome for creating a filter.
         """
         output_of_possible_filters = []
         registered_filter_wizards = CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS
@@ -62,17 +66,18 @@ class CustomFilterWizardStorage:
         **kwargs
     ) -> None:
         """
-            Method responsible for running loading definition of possible ways of
-            building filters in the specific provided custom filter wizard class.
+        Run the loading of definitions for possible ways of building filters in the provided
+        custom filter wizard class.
 
-            :param wizard_filter_class: dictionary which cointains the information
-             about particular registered CustomWizardClass where there is implemented method
-             how to load such definitions of possbile way of building filters
-            :param output_of_possible_filters: the list that contains the definitions
-             how to build filters. In that context is appended to such list if there are any
-             specific definitions of filters for particular field.
+        Args:
+            wizard_filter_class (CustomFilterWizardInterface): An instance of the custom filter wizard class
+                                                              responsible for loading filter definitions.
+            output_of_possible_filters (list): A list that contains the definitions of how to build filters.
+                                              Any specific definitions for a particular field will be appended
+                                              to this list.
 
-            :return: None (void method)
+        Returns:
+            None: This is a void method.
         """
         wizard_filter_tuple_type = namedtuple(
             wizard_filter_class.get_type_of_object(),
@@ -84,26 +89,30 @@ class CustomFilterWizardStorage:
     @classmethod
     def __create_instance_of_wizard_class(cls, registered_filter_wizard: dict) -> CustomFilterWizardInterface:
         """
-            Method responsible to create instance of custom filter wizard class
+        Create an instance of the custom filter wizard class.
 
-            :param registered_filter_wizard: dictionary which cointains the information
-             about particular registered CustomWizardClass
+        Args:
+            registered_filter_wizard (dict): A dictionary containing information about the particular
+                                             registered CustomWizardClass.
 
-            :return: bool
+        Returns:
+            CustomFilterWizardInterface: An instance of the custom filter wizard class.
         """
         return registered_filter_wizard[cls.__KEY_FOR_OBTAINING_CLASS]()
 
     @classmethod
     def __check_object_type(cls, wizard_filter_class: CustomFilterWizardInterface, object_type: str) -> bool:
         """
-            Verify if such object is matched to the object definied in instance of class responsible for
-            implementing wizard interface in given object type
+        Verify if the object is matched to the object defined in the instance of the class responsible for
+        implementing the wizard interface in the given object type.
 
-            :param wizard_filter_class: the instance of class responsible for implementation of
-             CustomFilterWizardInterface in given object type
-            :param object_type: string representation of object class that take a part in
-             filtering customization.
+        Args:
+            wizard_filter_class (CustomFilterWizardInterface): An instance of the class responsible for
+                                                              implementing the CustomFilterWizardInterface
+                                                              in the given object type.
+            object_type (str): The string representation of the object class that takes part in filtering customization.
 
-            :return: bool
+        Returns:
+            bool: True if the object is matched, False otherwise.
         """
         return object_type == wizard_filter_class.get_type_of_object()

--- a/core/custom_filters/custom_filter_wizard_storage.py
+++ b/core/custom_filters/custom_filter_wizard_storage.py
@@ -28,7 +28,7 @@ class CustomFilterWizardStorage:
     __VALUE = 'value'
 
     @classmethod
-    def build_output_how_to_build_filter(cls, module_name: str, object_type: str) -> List[namedtuple]:
+    def build_output_how_to_build_filter(cls, module_name: str, object_type: str, **kwargs) -> List[namedtuple]:
         """
             Building the final outcome how to build filter based on the information provided
             by registered custom filter wizard based on the provided module name and type of object.
@@ -51,14 +51,15 @@ class CustomFilterWizardStorage:
                 if cls.__KEY_FOR_OBTAINING_CLASS in registered_filter_wizard:
                     wizard_filter_class = cls.__create_instance_of_wizard_class(registered_filter_wizard)
                     if cls.__check_object_type(wizard_filter_class, object_type):
-                        cls.__run_load_definition_object_in_wizard(wizard_filter_class, output_of_possible_filters)
+                        cls.__run_load_definition_object_in_wizard(wizard_filter_class, output_of_possible_filters, **kwargs)
         return output_of_possible_filters
 
     @classmethod
     def __run_load_definition_object_in_wizard(
         cls,
         wizard_filter_class: CustomFilterWizardInterface,
-        output_of_possible_filters: List[namedtuple]
+        output_of_possible_filters: List[namedtuple],
+        **kwargs
     ) -> None:
         """
             Method responsible for running loading definition of possible ways of
@@ -77,7 +78,7 @@ class CustomFilterWizardStorage:
             wizard_filter_class.get_type_of_object(),
             [cls.__FIELD, cls.__FILTER, cls.__VALUE]
         )
-        tuple_list_result = wizard_filter_class.load_definition(wizard_filter_tuple_type)
+        tuple_list_result = wizard_filter_class.load_definition(wizard_filter_tuple_type, **kwargs)
         output_of_possible_filters.extend(tuple_list_result)
 
     @classmethod

--- a/core/custom_filters/custom_filter_wizard_storage.py
+++ b/core/custom_filters/custom_filter_wizard_storage.py
@@ -30,89 +30,56 @@ class CustomFilterWizardStorage:
     __VALUE = 'value'
 
     @classmethod
-    def build_output_how_to_build_filter(cls, module_name: str, object_type: str, **kwargs) -> List[namedtuple]:
+    def build_custom_filters_definition(cls, module_name: str, object_type: str, **kwargs) -> List[namedtuple]:
         """
-            Build the final outcome for creating a filter based on the information provided by
-            a registered custom filter wizard for the specified module name and object type.
+        Build the final outcome for creating a filter based on the information provided by
+        a registered custom filter wizard for the specified module name and object type.
 
-            The output is a list of named tuples (from the collections package). Each named tuple is built
-            in the following format: <Type>(field=<str>, filter=<str>, value=<str>)
+        The output is a list of named tuples (from the collections package). Each named tuple is built
+        in the following format: <Type>(field=<str>, filter=<str>, value=<str>)
 
-            Example named tuple: BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
+        Example named tuple: BenefitPlan(field='income', filter='lt, gte, icontains, exact', value='')
 
-            Args:
-                module_name (str): The name of the module installed in openIMIS, required to retrieve information
-                                   about the possible ways of building filters for that specific module.
-                object_type (str): The name of the object type for which the filter building information is needed.
+        :param module_name: The name of the module installed in openIMIS, required to retrieve information
+                            about the possible ways of building filters for that specific module.
+        :type module_name: str
+        :param object_type: The name of the object type for which the filter building information is needed.
+        :type object_type: str
 
-            Returns:
-                List[namedtuple]: A list of named tuples representing the final outcome for creating a filter.
+        :return: A list of named tuples representing the final outcome for creating a filter.
+        :rtype: List[namedtuple]
         """
         output_of_possible_filters = []
         registered_filter_wizards = CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS
         if module_name in registered_filter_wizards:
             for registered_filter_wizard in registered_filter_wizards[module_name]:
-                if cls.__KEY_FOR_OBTAINING_CLASS in registered_filter_wizard:
-                    wizard_filter_class = cls.__create_instance_of_wizard_class(registered_filter_wizard)
-                    if cls.__check_object_type(wizard_filter_class, object_type):
-                        cls.__run_load_definition_object_in_wizard(wizard_filter_class, output_of_possible_filters, **kwargs)
+                if cls.__KEY_FOR_OBTAINING_CLASS not in registered_filter_wizard:
+                    continue
+                wizard_filter_class = cls.__create_instance_of_wizard_class(registered_filter_wizard)
+                if not cls.__check_object_type(wizard_filter_class, object_type):
+                    continue
+                output_of_possible_filters.extend(
+                    cls.__run_load_definition_object_in_wizard(wizard_filter_class, **kwargs)
+                )
         return output_of_possible_filters
 
     @classmethod
     def __run_load_definition_object_in_wizard(
         cls,
         wizard_filter_class: CustomFilterWizardInterface,
-        output_of_possible_filters: List[namedtuple],
         **kwargs
-    ) -> None:
-        """
-        Run the loading of definitions for possible ways of building filters in the provided
-        custom filter wizard class.
-
-        Args:
-            wizard_filter_class (CustomFilterWizardInterface): An instance of the custom filter wizard class
-                                                              responsible for loading filter definitions.
-            output_of_possible_filters (list): A list that contains the definitions of how to build filters.
-                                              Any specific definitions for a particular field will be appended
-                                              to this list.
-
-        Returns:
-            None: This is a void method.
-        """
+    ) -> List[namedtuple]:
         wizard_filter_tuple_type = namedtuple(
             wizard_filter_class.get_type_of_object(),
             [cls.__FIELD, cls.__FILTER, cls.__VALUE]
         )
         tuple_list_result = wizard_filter_class.load_definition(wizard_filter_tuple_type, **kwargs)
-        output_of_possible_filters.extend(tuple_list_result)
+        return tuple_list_result
 
     @classmethod
     def __create_instance_of_wizard_class(cls, registered_filter_wizard: dict) -> CustomFilterWizardInterface:
-        """
-        Create an instance of the custom filter wizard class.
-
-        Args:
-            registered_filter_wizard (dict): A dictionary containing information about the particular
-                                             registered CustomWizardClass.
-
-        Returns:
-            CustomFilterWizardInterface: An instance of the custom filter wizard class.
-        """
         return registered_filter_wizard[cls.__KEY_FOR_OBTAINING_CLASS]()
 
     @classmethod
     def __check_object_type(cls, wizard_filter_class: CustomFilterWizardInterface, object_type: str) -> bool:
-        """
-        Verify if the object is matched to the object defined in the instance of the class responsible for
-        implementing the wizard interface in the given object type.
-
-        Args:
-            wizard_filter_class (CustomFilterWizardInterface): An instance of the class responsible for
-                                                              implementing the CustomFilterWizardInterface
-                                                              in the given object type.
-            object_type (str): The string representation of the object class that takes part in filtering customization.
-
-        Returns:
-            bool: True if the object is matched, False otherwise.
-        """
         return object_type == wizard_filter_class.get_type_of_object()


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/CM-68

PR delivers:
- Interface for CustomFilterWizard
- Registry point to obtain from particular module (on its apps.py file) information about implemented above interfaces while core module initialization
- Core Hub (storage) to build output how to build filters for particular object type 

The way how it works is below. This is the concept how it could work. Based on mocked fixed implementation of interfaces in social_protection module (real logic will be implemented within CM-69 ticket). If you have some ideas how to improve this solution at this stage please let me know in the review comments. 

- mocked implementation of interfaces for creation of custom filters
![Screenshot from 2023-05-26 11-10-37](https://github.com/openimis/openimis-be-core_py/assets/52816247/785f8d65-81f1-4cee-8ad8-36cac1dad2e4)
- mocked custom_filter.py file in policy module
![Screenshot from 2023-05-31 09-41-45](https://github.com/openimis/openimis-be-core_py/assets/52816247/3e0e1d0c-8d60-446b-a8b1-bac9ac56624f)
![Screenshot from 2023-05-31 21-02-34](https://github.com/openimis/openimis-be-core_py/assets/52816247/cf4a6d2b-85c3-401b-98d4-88b9f4a44e37)

- some operations on that service responsible for creating output based on given context from mocked implementation of services etc
![Screenshot from 2023-05-31 21-07-17](https://github.com/openimis/openimis-be-core_py/assets/52816247/3e53479b-8901-4492-94dd-31f1ffae5015)
![Screenshot from 2023-05-31 21-11-20](https://github.com/openimis/openimis-be-core_py/assets/52816247/82f24c13-32bd-4e31-9e17-587e4463c0b6)



NOTE: While working on CM-69 I will create graphQL query which will be necessary for frontend (CM-71) in order to retrieve such information how to build such filters per particular object type (for example how to build filters based on data provided from schema defined in BenefitPlan(CM-69))

2nd NOTE: We could think about Registry point as a generic solution. Similar actions happens inside registering calculation rules in calculation modules, registering appscheduler tasks, signals and grapgQL schema within assembly module. But this could be a proposal of improvement when we have the time and space for such improvements.