### PR TITLE
Fixed UserGroup model table name and managed

### DIFF
--- a/core/migrations/0020_add_missing_fields_to_django_scheme.py
+++ b/core/migrations/0020_add_missing_fields_to_django_scheme.py
@@ -237,6 +237,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterModelTable(
             name='usergroup',
-            table='Core_User_groups',
+            table='core_User_groups',
         ),
     ]

--- a/core/models.py
+++ b/core/models.py
@@ -684,8 +684,8 @@ class UserGroup(models.Model):
     group = models.ForeignKey(Group, models.DO_NOTHING)
 
     class Meta:
-        managed = True
-        db_table = 'Core_User_groups'
+        managed = False
+        db_table = 'core_User_groups'
         unique_together = (('user', 'group'),)
 
 


### PR DESCRIPTION
- Changed UserGroup model `managed` metafield to `False` as the UserGroup is a model for auto generated many to many table and `managed = True` causes django to try and create a second table.
- Changed name capitalization for UserGroup table to the correct one to avoid any errors related to table names. Postgres database by default makes table names case insensitive, but it can be forced to check the capitalization.