### PR TITLE
test fix async

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -200,8 +200,10 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
                         coerced_list.append(item)
                 coerced_data[key] = coerced_list
             elif isinstance(value, str):
-                coerced_data[key] = field.type.parse_value(field_type,value)
-            return coerced_data
+                coerced_data[key] = field.type.parse_value(value)
+            else:
+                coerced_data[key] = value
+        return coerced_data
         
     @classmethod
     def async_mutate(cls, user, **data) -> List[Dict[str, Any]]:

--- a/core/schema.py
+++ b/core/schema.py
@@ -181,28 +181,38 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
             description="Extension data to be used by signals. Will not be pushed to mutation implementation.")
 
     @classmethod
-    def coerce_mutation_data(cls, input_data):
+    def coerce_mutation_data(cls, input_data, input_class = None):
+        if input_class is None:
+            input_class=cls.Input
         coerced_data = {}
         # Iterate through the input data dictionary
         for key, value in input_data.items():
-            # Get the field type from the input class
-            field = getattr(cls.Input, key)
-
-            # If the field type is List and the value is a list
-            if isinstance(field.type, graphene.List) and isinstance(value, list):
-                # Check if the list items need coercion
-                inner_type = field.type.of_type
-                coerced_list = []
-                for item in value:
-                    if isinstance(item, str):
-                        coerced_list.append(inner_type.parse_value(item))
-                    else:
-                        coerced_list.append(item)
-                coerced_data[key] = coerced_list
-            elif isinstance(value, str):
-                coerced_data[key] = field.type.parse_value(value)
+            if hasattr(input_class, key):
+                # Get the field type from the input class
+                field = getattr(input_class, key)
+                # If the field type is List and the value is a list
+                if field.__class__ == graphene.List and isinstance(value, list):
+                    # Check if the list items need coercion
+                    inner_type = field.of_type
+                    coerced_list = []
+                    for item in value:
+                        if isinstance(item, str):
+                            coerced_list.append(inner_type.parse_value(item))
+                        elif inner_type.__class__ == graphene.utils.subclass_with_meta.SubclassWithMeta_Meta:
+                            coerced_list.append(cls.coerce_mutation_data(item, input_class = field))
+                        else:
+                            coerced_list.append(item)
+                    coerced_data[key] = coerced_list
+                elif isinstance(value, str):
+                    coerced_data[key] = field.parse_value(value)
+                elif field.__class__ == graphene.types.field.Field:
+                    coerced_data[key] = cls.coerce_mutation_data(value, input_class = field._type)
+                else:
+                    coerced_data[key] = value
             else:
+                logger.debug(f"key {key} not in {cls.__name__}")
                 coerced_data[key] = value
+           
         return coerced_data
         
     @classmethod

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -31,7 +31,7 @@ def openimis_mutation_async(mutation_id, module, class_name):
                 translation.activate(lang.code)
             else:
                 translation.activate(lang)
-        error_messages = mutation_class.async_mutate(mutation.user, **json.loads(mutation.json_content))
+        error_messages = mutation_class.async_mutate(mutation.user, **mutation_class.coerce_mutation_data(json.loads(mutation.json_content)))
         if not error_messages:
             mutation.mark_as_successful()
         else:


### PR DESCRIPTION
chatGTP doc:



Your tested version of coerce_mutation_data appears to be more comprehensive and handles various cases including nested input types. Here's a brief explanation of the key aspects:

Handling Nested Input Types: The method recursively handles nested input types by calling itself if the field type is a custom input object.

Checking Field Type: Instead of using field.type, it directly checks the class of the field (field.__class__). This allows more precise checking and handling of different types, such as graphene.List or custom input types.

Custom Input Types: For custom input types, it handles coercion by calling coerce_mutation_data recursively with the inner input class.

Logging: It includes logging for cases where a key is not found in the input class. This can be helpful for debugging.

Default Input Class: It allows specifying a default input class if input_class is not provided.

Overall, this version seems robust and capable of handling various scenarios encountered in mutation data coercion. Ensure to test it thoroughly with different input data and input class configurations to verify its correctness and effectiveness. If any specific business rules or requirements apply to your application, make sure they are properly accounted for in the coercion logic.
