### PR TITLE
Feature/cqi 153: add lockout mechanism for login functionality

### DIFF
--- a/core/jwt_authentication.py
+++ b/core/jwt_authentication.py
@@ -22,8 +22,6 @@ class JWTAuthentication(BaseAuthentication):
 
     def authenticate(self, request):
         token = get_credentials(request)
-        if not token:
-            raise exceptions.AuthenticationFailed("INCORRECT_CREDENTIALS")
 
         # Do not pass context to avoid to try to get user from request to get his private key.
         try:

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,17 @@
+from django.utils.timezone import now
+
+
+class DefaultAxesAttributesMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Set default values for Django-axes attributes if they're not already set
+        if not hasattr(request, 'axes_ip_address'):
+            request.axes_ip_address = request.META.get('REMOTE_ADDR', '')
+        if not hasattr(request, 'axes_user_agent'):
+            request.axes_user_agent = request.META.get('HTTP_USER_AGENT', '')
+        if not hasattr(request, 'axes_attempt_time'):
+            request.axes_attempt_time = now()
+
+        return self.get_response(request)

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -20,6 +20,7 @@ from .base import *
 from .versioned_model import *
 
 logger = logging.getLogger(__name__)
+from rest_framework import exceptions
 
 
 class UserManager(BaseUserManager):
@@ -51,8 +52,8 @@ class UserManager(BaseUserManager):
             i_user = InteractiveUser.objects.get(
                 login_name=kwargs['username'],
                 *filter_validity())
-        except InteractiveUser.DoesNotExist:
-            raise PermissionDenied
+        except InteractiveUser.DoesNotExist as e:
+            raise exceptions.AuthenticationFailed("INCORRECT_CREDENTIALS") from e
         user = self._create_core_user(**kwargs)
         user.i_user = i_user
         user.save()

--- a/core/schema.py
+++ b/core/schema.py
@@ -9,8 +9,10 @@ import graphene
 from django.utils.translation import gettext as _
 from copy import copy
 from datetime import datetime as py_datetime
+
 from functools import reduce
 from django.utils.translation import gettext_lazy
+from graphql.error import GraphQLError
 from graphene.types.generic import GenericScalar
 from graphql_jwt.mutations import JSONWebTokenMutation, mixins
 import graphene_django_optimizer as gql_optimizer
@@ -35,9 +37,12 @@ from django.db.models import Q, Count
 from django.db.models.expressions import RawSQL
 from django.http import HttpRequest
 from django.utils import translation
+from django.utils.timezone import now
 from graphene.utils.str_converters import to_snake_case, to_camel_case
 from graphene_django.filter import DjangoFilterConnectionField
 import graphql_jwt
+from axes.attempts import get_user_attempts
+from axes.handlers.database import AxesDatabaseHandler
 from typing import Optional, List, Dict, Any
 
 from .apps import CoreConfig
@@ -1573,6 +1578,8 @@ class OpenimisObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):
     @classmethod
     def mutate(cls, root, info, **kwargs):
         username = kwargs.get("username")
+        request = info.context
+        check_lockout(request)
         # consider auto-provisioning
         if username:
             # get_or_create will auto-provision from tblUsers if applicable
@@ -1641,3 +1648,26 @@ def on_user_mutation(sender, **kwargs):
 def bind_signals():
     signal_mutation_module_validate["core"].connect(on_role_mutation)
     signal_mutation_module_validate["core"].connect(on_user_mutation)
+
+
+
+def check_lockout(request):
+    attempts = get_user_attempts(request)
+    if attempts:
+        from django.db.models import Max
+        last_attempt_time = max(
+            (attempt.aggregate(Max('attempt_time'))['attempt_time__max'] for attempt in attempts if attempt.exists()),
+            default=None
+        )
+
+        if last_attempt_time:
+            handler = AxesDatabaseHandler()
+            failure_count = handler.get_failures(request)
+            if failure_count >= settings.AXES_FAILURE_LIMIT:
+                # Calculate the remaining time of the lockout
+                remaining_lockout_delta = settings.AXES_COOLOFF_TIME - (now() - last_attempt_time)
+                remaining_minutes = int(remaining_lockout_delta.total_seconds() / 60)
+                raise GraphQLError(
+                    f"Too many failed login attempts."
+                    f"Try again in {remaining_minutes} minutes."
+                )

--- a/core/services/userServices.py
+++ b/core/services/userServices.py
@@ -228,6 +228,14 @@ def create_or_update_core_user(user_uuid, username, i_user=None, t_user=None, of
 
 
 def change_user_password(logged_user, username_to_update=None, old_password=None, new_password=None):
+    print("-------------------------------")
+    print("-------------------------------")
+    print("-------------------------------")
+    print(old_password)
+    print(new_password)
+    print("-------------------------------")
+    print("-------------------------------")
+    print("-------------------------------")
     if username_to_update and username_to_update != logged_user.username:
         if not logged_user.has_perms(CoreConfig.gql_mutation_update_users_perms):
             raise PermissionDenied("unauthorized")

--- a/core/services/userServices.py
+++ b/core/services/userServices.py
@@ -228,14 +228,6 @@ def create_or_update_core_user(user_uuid, username, i_user=None, t_user=None, of
 
 
 def change_user_password(logged_user, username_to_update=None, old_password=None, new_password=None):
-    print("-------------------------------")
-    print("-------------------------------")
-    print("-------------------------------")
-    print(old_password)
-    print(new_password)
-    print("-------------------------------")
-    print("-------------------------------")
-    print("-------------------------------")
     if username_to_update and username_to_update != logged_user.username:
         if not logged_user.has_perms(CoreConfig.gql_mutation_update_users_perms):
             raise PermissionDenied("unauthorized")


### PR DESCRIPTION
BEFORE MERGING, CHECK THIS:
https://github.com/openimis/openimis-be_py/pull/243

Ticket:
https://openimis.atlassian.net/browse/CQI-153

Changes:
- lockout mechanism checks for numbers of attempts
- no token is being checked when authenticating, it allows to properly handles errors
- axes is added as a lockout mechanism tool

Tested:
- user can login
- user cannot login from given IP if numbers of tries exceeded the limit
- user with wrong credentials is informed, there is no "UNKOWN ERROR" anymore

PoC:
![Screenshot from 2024-05-13 10-42-46](https://github.com/openimis/openimis-be-core_py/assets/56487722/bf17461f-9a4c-4088-8a20-7be452ff9dd6)
![Screenshot from 2024-05-13 10-40-49](https://github.com/openimis/openimis-be-core_py/assets/56487722/2a7e8ff1-d1c1-4337-b226-3f3a28cbd7ce)
