### PR TITLE
CQI-154: increased length of username to 12

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -12,7 +12,7 @@ MODULE_NAME = "core"
 this = sys.modules[MODULE_NAME]
 
 DEFAULT_CFG = {
-    "username_code_length": "8",  # cannot be bigger than 50 unless modified length limit
+    "username_code_length": "12",  # cannot be bigger than 50 unless modified length limit
     "username_changeable": True,
     "auto_provisioning_user_group": "user",
     "calendar_package": "core",
@@ -58,7 +58,7 @@ DEFAULT_CFG = {
 class CoreConfig(AppConfig):
     default_auto_field = 'django.db.models.AutoField'  # Django 3.1+
     name = MODULE_NAME
-    username_code_length = 8
+    username_code_length = 12
     username_changeable = True
     age_of_majority = 18
     password_reset_template = "password_reset.txt"


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/CQI-154

This ticket was created to increase number of characters available in the username field. It has no minimal limit set, we discussed this on the meeting with stakeholders.