### PR TITLE
CQI-148: strenghten password policy for new user

### DIFF
--- a/core/models/user.py
+++ b/core/models/user.py
@@ -12,6 +12,7 @@ from django.db import models
 from django.utils.crypto import salted_hmac
 from graphql import ResolveInfo
 import core
+from core.utils import validate_password
 #from core.datetimes.ad_datetime import datetime as py_datetime
 from django.conf import settings
 
@@ -294,7 +295,7 @@ class InteractiveUser(VersionedModel):
     def set_password(self, raw_password):
         from hashlib import sha256
         from secrets import token_hex
-
+        validate_password(raw_password)
         self.private_key = token_hex(128)
         pwd_hash = sha256()
         pwd_hash.update(f"{raw_password.rstrip()}{self.private_key}".encode())

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,6 +4,9 @@ from importlib import import_module
 from typing import Type, Dict, Any
 
 import jsonschema
+from password_validator import PasswordValidator
+from zxcvbn import zxcvbn
+from graphql import GraphQLError
 
 import core
 import ast
@@ -14,6 +17,7 @@ from django.db.models import Q
 from django.utils.translation import gettext as _
 import logging
 from django.apps import apps
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.files.storage import default_storage
 
@@ -34,6 +38,7 @@ __all__ = [
     "ExtendedConnection",
     "get_scheduler_method_ref",
     "ExtendedRelayConnection",
+    "validate_password"
 ]
 
 
@@ -325,6 +330,34 @@ def validate_json_schema(schema):
         return [{"message": _("core.utils.schema_validation.invalid_json" % {
             'error': str(json_error)
         })}]
+
+
+def validate_password(password: str) -> None:
+    schema = PasswordValidator()
+    schema.min(settings.PASSWORD_MIN_LENGTH)
+    requirements = {
+        'PASSWORD_UPPERCASE': 'uppercase',
+        'PASSWORD_LOWERCASE': 'lowercase',
+        'PASSWORD_DIGITS': 'digits',
+        'PASSWORD_SYMBOLS': 'symbols'
+    }
+
+    for setting, method in requirements.items():
+        if getattr(settings, setting) > 0:
+            getattr(schema.has(), method)()
+
+    if not schema.validate(password):
+        raise GraphQLError(
+            f"Password must be at least {settings.PASSWORD_MIN_LENGTH} characters long, "
+            f"have at least {settings.PASSWORD_UPPERCASE} uppercase letter(s), "
+            f"{settings.PASSWORD_LOWERCASE} lowercase letter(s), "
+            f"{settings.PASSWORD_DIGITS} number(s), and "
+            f"{settings.PASSWORD_SYMBOLS} special character(s)."
+        )
+    # Use zxcvbn to check against common patterns and dictionary words
+    zxcvbn_result = zxcvbn(password)
+    if zxcvbn_result['score'] < 3:
+        raise GraphQLError("Password is too weak. Avoid common patterns and dictionary words.")
 
 
 class DefaultStorageFileHandler:


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/CQI-148

Related: 
https://github.com/openimis/openimis-be_py/pull/244

Changes:
- password policy is set
- password cannot contain any dictionary or typical password
- password must contain small leter, capital, number and special characters
- password is at least 12 characters long

Those are default value, it will be configurable for each implementation with be_py PR.

How was it tested?
1. Proper error handling for password_validator
![Screenshot from 2024-05-14 17-50-56](https://github.com/openimis/openimis-be-core_py/assets/56487722/31a43f5d-b259-4eae-a6ad-386f5dcf4174)

2. Proper error handling for typical password and dictionaries
![Screenshot from 2024-05-14 17-51-05](https://github.com/openimis/openimis-be-core_py/assets/56487722/aeaaa5a7-de03-4b68-bf19-257b12546123)

3. User can be created if the password is strong:
![Screenshot from 2024-05-14 17-51-29](https://github.com/openimis/openimis-be-core_py/assets/56487722/8c6c1377-6414-42ee-b270-810316fc04c9)
