### PR TITLE
CQI-164: administrator cannot deprovision himslef

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -1448,9 +1448,7 @@ def update_or_create_user(data, user):
         data.pop('client_mutation_label')
     user_uuid = data.pop('uuid') if 'uuid' in data else None
 
-    current_roles = Role.objects.filter(id__in=data.get("roles", []))
-    is_admin_role = any(role.is_system == imis_administrator_system for role in current_roles)
-    if user_uuid == str(user.id) and not is_admin_role:
+    if user_uuid == str(user.id) and user.is_imis_admin and imis_administrator_system not in data.get("roles",[]):
         raise ValidationError("Administrator cannot deprovision himself.")
 
     if UT_INTERACTIVE in data["user_types"]:


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/CQI-164

Changes:
- administrator cannot deprovision himself (IMIS Administrator role)

How was it tested?

1. admin can deprovision some other roles

![Screenshot from 2024-05-24 11-32-59](https://github.com/openimis/openimis-be-core_py/assets/56487722/24086074-6791-40ba-b86b-2fd8db83fbb4)
![Screenshot from 2024-05-24 11-32-55](https://github.com/openimis/openimis-be-core_py/assets/56487722/bb6efc79-41c2-478c-ac7b-2f0f9ab8d3cf)


2. attempt of deleting his own admin role will be prohibited

![Screenshot from 2024-05-24 11-33-23](https://github.com/openimis/openimis-be-core_py/assets/56487722/aaef7f15-76a7-4183-8ac7-aca348641b81)

![Screenshot from 2024-05-24 11-33-44](https://github.com/openimis/openimis-be-core_py/assets/56487722/246c81f2-ec00-4bdf-8954-9ce1981e89cc)
