### PR TITLE
Moved security headers for PROD only

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -32,7 +32,7 @@ class SecurityHeadersMiddleware:
             response["Content-Security-Policy"] = "default-src 'self';"
             response["X-Frame-Options"] = "DENY"
             response["X-Content-Type-Options"] = "nosniff"
-            response["Referrer-Policy"] = "no-referrer"
+            response["Referrer-Policy"] = "strict-origin-when-cross-origin"
             response["Permissions-Policy"] = "geolocation=(), microphone=()"
 
         return response

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -29,12 +29,11 @@ class SecurityHeadersMiddleware:
 
         if settings.MODE == "PROD":
             response["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
-
-        response["Content-Security-Policy"] = "default-src 'self';"
-        response["X-Frame-Options"] = "DENY"
-        response["X-Content-Type-Options"] = "nosniff"
-        response["Referrer-Policy"] = "no-referrer"
-        response["Permissions-Policy"] = "geolocation=(), microphone=()"
+            response["Content-Security-Policy"] = "default-src 'self';"
+            response["X-Frame-Options"] = "DENY"
+            response["X-Content-Type-Options"] = "nosniff"
+            response["Referrer-Policy"] = "no-referrer"
+            response["Permissions-Policy"] = "geolocation=(), microphone=()"
 
         return response
 


### PR DESCRIPTION
Changes:
- moved security headers to PROD because it caused issue on some local instances with admin panel. Some browser don't add Origin when running the application from localhost.
- changed referrer header