### PR TITLE
Refactor & move LogInHelper to core module to keep it DRY

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - "core/tests/*.py"

--- a/core/test_helpers.py
+++ b/core/test_helpers.py
@@ -141,15 +141,17 @@ class LogInHelper:
             "roles": [1, 3, 5, 9],
         }
 
-    def get_or_create_user_api(self):
-        user = User.objects.filter(username=self.test_user_name).first()
+    def get_or_create_user_api(self, **kwargs):
+        username = kwargs.get('username') or self.test_user_name
+        user = User.objects.filter(username=username).first()
         if user is None:
-            user = self._create_user_interactive_core()
+            user = self._create_user_interactive_core(**kwargs)
         return user
 
-    def _create_user_interactive_core(self):
+    def _create_user_interactive_core(self, **kwargs):
+        username = kwargs.get('username') or self.test_user_name
         i_user, i_user_created = create_or_update_interactive_user(
-            user_id=None, data=self.test_data_user, audit_user_id=999, connected=False)
+            user_id=None, data={**self.test_data_user, **kwargs}, audit_user_id=999, connected=False)
         create_or_update_core_user(
-            user_uuid=None, username=self.test_data_user["username"], i_user=i_user)
-        return User.objects.get(username=self.test_user_name)
+            user_uuid=None, username=username, i_user=i_user)
+        return User.objects.get(username=username)

--- a/core/test_helpers.py
+++ b/core/test_helpers.py
@@ -1,6 +1,6 @@
 from core.models import Officer, InteractiveUser, User, TechnicalUser, filter_validity
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase
-from core.services.userServices import create_or_update_officer_villages
+from core.services.userServices import create_or_update_officer_villages,  create_or_update_interactive_user, create_or_update_core_user
 from core.services import create_or_update_user_roles
 from location.models import Location
 from  uuid import uuid4
@@ -42,7 +42,7 @@ def create_test_officer(valid=True, custom_props={}, villages = []):
         result = create_or_update_officer_villages(eo, [v.id for v in villages], 1)
         return eo
 
-def create_test_interactive_user(username='TestInteractiveTest', password="Test1234", roles=None, custom_props=None):
+def create_test_interactive_user(username='TestInteractiveTest', password="S\/pe®Pąßw0rd""", roles=None, custom_props=None):
     if roles is None:
         roles = [7, 1, 2, 3, 4, 5, 6]
     i_user = InteractiveUser.objects.create(
@@ -127,3 +127,29 @@ def AssertMutation(test_obj,mutation_uuid, token ):
     return openIMISGraphQLTestCase().get_mutation_result(mutation_uuid, token)
 
 
+class LogInHelper:
+    def __init__(self):
+        self.test_user_name = "TestUserTest2"
+        self.test_user_password = "TestPasswordTest2@"
+        self.test_data_user = {
+            "username": self.test_user_name,
+            "last_name": self.test_user_name,
+            "password": self.test_user_password,
+            "other_names": self.test_user_name,
+            "user_types": "INTERACTIVE",
+            "language": "en",
+            "roles": [1, 3, 5, 9],
+        }
+
+    def get_or_create_user_api(self):
+        user = User.objects.filter(username=self.test_user_name).first()
+        if user is None:
+            user = self._create_user_interactive_core()
+        return user
+
+    def _create_user_interactive_core(self):
+        i_user, i_user_created = create_or_update_interactive_user(
+            user_id=None, data=self.test_data_user, audit_user_id=999, connected=False)
+        create_or_update_core_user(
+            user_uuid=None, username=self.test_data_user["username"], i_user=i_user)
+        return User.objects.get(username=self.test_user_name)

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -20,6 +20,7 @@ from location.models import OfficerVillage
 
 logger = logging.getLogger(__file__)
 postgresql = "postgresql"
+PASSWORD = "FoBoar72!"
 
 
 class UserServicesTest(TestCase):
@@ -76,7 +77,7 @@ class UserServicesTest(TestCase):
                 phone="+123456789",
                 email=f"{username}@illuminati.int",
                 health_facility_id=1,
-                password="foobar123",
+                password=PASSWORD,
             ),
             audit_user_id=999,
             connected=False,
@@ -95,8 +96,8 @@ class UserServicesTest(TestCase):
         self.assertEquals(i_user.phone, "+123456789")
         self.assertEquals(i_user.email, f"{username}@illuminati.int")
         self.assertIsNotNone(i_user.password)
-        self.assertNotEqual(i_user.password, "foobar123")  # No clear text password
-        self.assertTrue(i_user.check_password("foobar123"))
+        self.assertNotEqual(i_user.password, PASSWORD)  # No clear text password
+        self.assertTrue(i_user.check_password(PASSWORD))
         self.assertFalse(i_user.check_password("wrong_password"))
 
         UserRole.objects.filter(user_id=i_user.id).delete()
@@ -118,7 +119,7 @@ class UserServicesTest(TestCase):
                 phone="+123456789",
                 email=f"{username}@illuminati.int",
                 health_facility_id=1,
-                password="foobar123",
+                password=PASSWORD,
             ),
             audit_user_id=999,
             connected=False,
@@ -136,7 +137,7 @@ class UserServicesTest(TestCase):
         self.assertEquals(i_user.language.code, "fr")
         self.assertEquals(i_user.phone, "+123456789")
         self.assertEquals(i_user.email, f"{username}@illuminati.int")
-        self.assertTrue(i_user.check_password("foobar123"))
+        self.assertTrue(i_user.check_password(PASSWORD))
 
         # Core user necessary for the update
         core_user, core_user_created = create_or_update_core_user(
@@ -154,7 +155,7 @@ class UserServicesTest(TestCase):
                 phone="updated phone",
                 email=f"{username}@updated.int",
                 health_facility_id=2,
-                password="updated",
+                password=f"{PASSWORD}updated",
             ),
             audit_user_id=111,
             connected=False,
@@ -179,7 +180,7 @@ class UserServicesTest(TestCase):
         self.assertEquals(i_user2.language.code, "en")
         self.assertEquals(i_user2.phone, "updated phone")
         self.assertEquals(i_user2.email, f"{username}@updated.int")
-        self.assertTrue(i_user2.check_password("updated"))
+        self.assertTrue(i_user2.check_password(f"{PASSWORD}updated"))
 
         UserRole.objects.filter(user_id=i_user.id).delete()
         core_user.delete()
@@ -453,13 +454,13 @@ class UserServicesTest(TestCase):
                 phone="+123456789",
                 email=f"{username}@illuminati.int",
                 health_facility_id=1,
-                password="foobar123",
+                password=PASSWORD,
             ),
             audit_user_id=999,
             connected=False,
         )
         self.assertTrue(created)
-        self.assertTrue(i_user.check_password("foobar123"))
+        self.assertTrue(i_user.check_password(PASSWORD))
 
         # Core user necessary for the update
         core_user, core_user_created = create_or_update_core_user(
@@ -492,13 +493,13 @@ class UserServicesTest(TestCase):
                 phone="+123456789",
                 email=f"{username}@illuminati.int",
                 health_facility_id=1,
-                password="foobar123",
+                password=PASSWORD,
             ),
             audit_user_id=999,
             connected=False,
         )
         self.assertTrue(created)
-        self.assertTrue(i_user.check_password("foobar123"))
+        self.assertTrue(i_user.check_password(PASSWORD))
         # Core user necessary for the update
         core_user, _ = create_or_update_core_user(None, username, i_user=i_user)
 

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -1,35 +1,25 @@
 from django.test import TestCase
-from core.services.userServices import create_or_update_interactive_user, create_or_update_core_user
-from core.test_helpers import create_test_officer
+from core.test_helpers import create_test_officer, LogInHelper
 import re
-from core.models import InteractiveUser
-# Create your tests here.
-null = None
+from core.models import InteractiveUser, Officer, User
 
 
 class HelpersTest(TestCase):
-    test_office = None
-    i_user= None
-    user = None
-    _TEST_USER_NAME = "testhelperusersername"
-    _TEST_USER_PASSWORD = "TestPasswordTest2"
-    _TEST_DATA_USER = {
-    "username": _TEST_USER_NAME,
-    "last_name": _TEST_USER_NAME,
-    "password": _TEST_USER_PASSWORD,
-    "other_names": _TEST_USER_NAME,
-    "user_types": "INTERACTIVE",
-    "language": "en",
-    "roles": [1, 3, 5, 9],
-    }
-    @classmethod
-    def setUpTestData(cls):
-        cls.test_officer = create_test_officer(valid=True, custom_props={})
-        cls.i_user, i_user_created = create_or_update_interactive_user(user_id=None, data=cls._TEST_DATA_USER, audit_user_id=999, connected=False)
-        cls.user, user_created = create_or_update_core_user(None, cls.i_user.username, i_user=cls.i_user)
 
-    def test_defautl(self):
-        self.assertEquals(self.user.username, self._TEST_USER_NAME)
+    def test_create_test_officer(self):
+        count_before = Officer.objects.count()
+        user = create_test_officer(valid=True, custom_props={})
+        self.assertTrue(type(user) is Officer)
+        count_after = Officer.objects.count()
+        self.assertEquals(count_after, count_before+1)
+
+    def test_login_helper(self):
+        count_before = InteractiveUser.objects.count()
+        login_helper = LogInHelper()
+        user = login_helper.get_or_create_user_api()
+        self.assertTrue(type(user) is User)
+        count_after = InteractiveUser.objects.count()
+        self.assertEquals(count_after, count_before+1)
 
 
 class GQLTest(TestCase):
@@ -46,13 +36,13 @@ class GQLTest(TestCase):
 			"healthFacilityId": "6",
 			"language": "en",
 			"lastName": "Manal",
-			"locationId": null,
+			"locationId": None,
 			"otherNames": "Roger",
-			"phone": null,
+			"phone": None,
 			"roles": [
 				"9"
 			],
-			"substitutionOfficerId": null,
+			"substitutionOfficerId": None,
 			"username": "VHOS0011",
 			"userTypes": [
 				"INTERACTIVE",


### PR DESCRIPTION
Also update test passwords to avoid ValidationError.

<img width="459" alt="image" src="https://github.com/openimis/openimis-be-core_py/assets/412533/0aba1e89-1113-42db-9f81-d2571123205c">

PRs refactoring other modules using LogInHelper to follow https://github.com/search?q=org%3Aopenimis+LogInHelper%28%29.get_or_create_user_api%28%29&type=code