### PR TITLE
fixed wrong key access error in user create and update flow

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -1534,7 +1534,7 @@ def update_or_create_user(data, user):
         
         if uuid.UUID(str(user_uuid)) == uuid.UUID(str(user.id)) and user.is_imis_admin and imis_administrator_system not in data.get("roles", []):
             raise ValidationError("Administrator cannot deprovision himself.")
-        current_user = InteractiveUser.objects.filter(user__id=data['uuid']).first()
+        current_user = InteractiveUser.objects.filter(user__id=user_uuid).first()
 
         current_email = current_user.email if current_user else None
 


### PR DESCRIPTION
Some recent change might have caused this issue. "uuid" key was being accessed from data object where this key have already been "poped". 
This error causes breakage in admin user creation and update.