### PR TITLE
feat: BaseService align json_ext value with payload field value

### DIFF
--- a/core/services/base.py
+++ b/core/services/base.py
@@ -7,6 +7,7 @@ from core.models import HistoryModel, MutationLog
 from core.services.utils import check_authentication as check_authentication, output_exception, \
     model_representation, output_result_success, build_delete_instance_payload
 from core.validation.base import BaseModelValidation
+from core.utils import json_serialize_value
 
 
 class BaseService(ABC):
@@ -68,7 +69,15 @@ class BaseService(ABC):
         return self._base_payload_adjust(payload_data)
 
     def _adjust_update_payload(self, payload_data):
+        self._align_json_ext(payload_data)
         return self._base_payload_adjust(payload_data)
+
+    def _align_json_ext(self, payload_data):
+        json_ext = payload_data.get('json_ext')
+        if isinstance(json_ext, dict):
+            for key, value in payload_data.items():
+                if key in json_ext and json_ext[key] != value:
+                    json_ext[key] = json_serialize_value(value)
 
     def _base_payload_adjust(self, obj_data):
         return obj_data

--- a/core/services/base.py
+++ b/core/services/base.py
@@ -7,7 +7,7 @@ from core.models import HistoryModel, MutationLog
 from core.services.utils import check_authentication as check_authentication, output_exception, \
     model_representation, output_result_success, build_delete_instance_payload
 from core.validation.base import BaseModelValidation
-from core.utils import json_serialize_value
+from core.utils import to_json_safe_value
 
 
 class BaseService(ABC):
@@ -77,7 +77,7 @@ class BaseService(ABC):
         if isinstance(json_ext, dict):
             for key, value in payload_data.items():
                 if key in json_ext and json_ext[key] != value:
-                    json_ext[key] = json_serialize_value(value)
+                    json_ext[key] = to_json_safe_value(value)
 
     def _base_payload_adjust(self, obj_data):
         return obj_data

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1,10 +1,14 @@
 import os
+import datetime
+import uuid
+import decimal
 from django.test import TestCase
 from django.db import connections
 from django.test.runner import DiscoverRunner
 from django.test.utils import get_unique_databases_and_mirrors
 
-from core.utils import full_class_name, comparable
+from core.utils import full_class_name, comparable, json_serialize_value
+from core.datetimes.ad_datetime import AdDate, AdDatetime
 
 
 class ComparableTest(TestCase):
@@ -41,3 +45,22 @@ class UtilsTestCase(TestCase):
 
         self.assertEquals(full_class_name(
             1), 'int')
+
+    def test_json_serialize_value(self):
+        self.assertEquals(json_serialize_value(42), 42)
+        self.assertEquals(json_serialize_value("foo"), "foo")
+
+        uuid_obj = uuid.uuid4()
+        self.assertEquals(json_serialize_value(uuid_obj), str(uuid_obj))
+
+        date_obj = datetime.date(2025, 1, 1)
+        self.assertEquals(json_serialize_value(date_obj), str(date_obj))
+
+        ad_date_obj = AdDate(2025, 1, 1)
+        self.assertEquals(json_serialize_value(ad_date_obj), str(ad_date_obj))
+
+        ad_datetime_obj = AdDatetime(2025, 1, 1, 12, 0, 0)
+        self.assertEquals(json_serialize_value(ad_datetime_obj), str(ad_datetime_obj))
+
+        decimal_obj = decimal.Decimal("12345.6789")
+        self.assertEquals(json_serialize_value(decimal_obj), str(decimal_obj))

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -7,7 +7,7 @@ from django.db import connections
 from django.test.runner import DiscoverRunner
 from django.test.utils import get_unique_databases_and_mirrors
 
-from core.utils import full_class_name, comparable, json_serialize_value
+from core.utils import full_class_name, comparable, to_json_safe_value
 from core.datetimes.ad_datetime import AdDate, AdDatetime
 
 
@@ -47,20 +47,20 @@ class UtilsTestCase(TestCase):
             1), 'int')
 
     def test_json_serialize_value(self):
-        self.assertEquals(json_serialize_value(42), 42)
-        self.assertEquals(json_serialize_value("foo"), "foo")
+        self.assertEquals(to_json_safe_value(42), 42)
+        self.assertEquals(to_json_safe_value("foo"), "foo")
 
         uuid_obj = uuid.uuid4()
-        self.assertEquals(json_serialize_value(uuid_obj), str(uuid_obj))
+        self.assertEquals(to_json_safe_value(uuid_obj), str(uuid_obj))
 
         date_obj = datetime.date(2025, 1, 1)
-        self.assertEquals(json_serialize_value(date_obj), str(date_obj))
+        self.assertEquals(to_json_safe_value(date_obj), str(date_obj))
 
         ad_date_obj = AdDate(2025, 1, 1)
-        self.assertEquals(json_serialize_value(ad_date_obj), str(ad_date_obj))
+        self.assertEquals(to_json_safe_value(ad_date_obj), str(ad_date_obj))
 
         ad_datetime_obj = AdDatetime(2025, 1, 1, 12, 0, 0)
-        self.assertEquals(json_serialize_value(ad_datetime_obj), str(ad_datetime_obj))
+        self.assertEquals(to_json_safe_value(ad_datetime_obj), str(ad_datetime_obj))
 
         decimal_obj = decimal.Decimal("12345.6789")
-        self.assertEquals(json_serialize_value(decimal_obj), str(decimal_obj))
+        self.assertEquals(to_json_safe_value(decimal_obj), str(decimal_obj))

--- a/core/utils.py
+++ b/core/utils.py
@@ -366,6 +366,14 @@ def validate_json_schema(schema):
         ]
 
 
+def json_serialize_value(value):
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return str(value)
+
+
 class CustomPasswordValidator:
     def __init__(self, uppercase=0, lowercase=0, digits=0, symbols=0):
         self.schema = PasswordValidator()

--- a/core/utils.py
+++ b/core/utils.py
@@ -366,7 +366,7 @@ def validate_json_schema(schema):
         ]
 
 
-def json_serialize_value(value):
+def to_json_safe_value(value):
     try:
         json.dumps(value)
         return value


### PR DESCRIPTION
When a field is present both on the `payload['json_ext']` as well as on the payload directly with a different value, `payload['json_ext']` will take on the value from the field directly on the payload. This ensure data fields such as "first_name", "last_name" on `Individual` as well as on its `json_ext` to stay consistent during an update. This is currently implemented as a monkey patch on Individual's service: https://github.com/openimis/openimis-be-individual_py/blob/develop/individual/services.py#L113-L127. It can be removed once this change is in.