### PR TITLE
fix: add missing translation for unauthorized.location

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -24,6 +24,9 @@ msgstr ""
 msgid "unauthorized"
 msgstr "User not authorized for this operation"
 
+msgid "unauthorized.location"
+msgstr "User not authorized for this operation due to limited location permissions"
+
 #: core/schema.py:1537
 msgid "mutation.user_email_invalid"
 msgstr ""


### PR DESCRIPTION
Used in individuals module but translation is not defined anywhere: https://github.com/search?q=org%3Aopenimis%20unauthorized.location&type=code