### PR TITLE
Performance improvements : Index on ClaimMutationID

### DIFF
--- a/core/models/base_mutation.py
+++ b/core/models/base_mutation.py
@@ -79,7 +79,7 @@ class MutationLog(UUIDModel, ExtendableModel):
     user = models.ForeignKey(User, on_delete=DO_NOTHING, blank=True, null=True)
     request_date_time = models.DateTimeField(auto_now_add=True)
     client_mutation_id = models.CharField(
-        max_length=255, blank=True, null=True)
+        max_length=255, blank=True, null=True, db_index=True)
     client_mutation_label = models.CharField(
         max_length=255, blank=True, null=True)
     client_mutation_details = models.TextField(blank=True, null=True)


### PR DESCRIPTION
MutationLog request per ClientMutationID is one of the most common request in the database.

On a fresh install this kind of request is not really challenging, but for hundreds of uses and millions of mutation in the table without index, the database is really struggling.