### PR TITLE
OS-89: added csrf token processing and csrf agent bypass

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -1782,6 +1782,12 @@ class OpenimisObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):
         password = kwargs.get("password")
         request = info.context
 
+        if CoreConfig.csrf_protect_login:
+            csrf_middleware = CsrfViewMiddleware(lambda req: None)
+            reason = csrf_middleware.process_view(request, None, (), {})
+            if reason:
+                raise PermissionDenied('CSRF token missing or incorrect.')
+
         check_lockout(request)
         info.context.user = user_authentication(request, username, password)
 

--- a/core/schema.py
+++ b/core/schema.py
@@ -73,7 +73,7 @@ from core.serializers import InteractiveUserSerializer
 
 MAX_SMALLINT = 32767
 MIN_SMALLINT = -32768
-EXPECTED_REQUESTED_WITH = 'webapp'
+WEBAPP_EXPECTED_REQUESTED_WITH = 'webapp'
 
 core = sys.modules["core"]
 
@@ -281,7 +281,7 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
         csrf_token = request.headers.get("X-CSRFToken")
         requested_with = request.headers.get("X-Requested-With")
         stored_token = cache.get(f"csrf_token_{request.user.id}")
-        if requested_with == EXPECTED_REQUESTED_WITH:
+        if requested_with == WEBAPP_EXPECTED_REQUESTED_WITH:
             if not csrf_token or csrf_token != stored_token:
                 response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
                 raise HttpError(response)
@@ -527,7 +527,7 @@ class OrderedDjangoFilterConnectionField(DjangoFilterConnectionField):
         csrf_token = request.headers.get("X-CSRFToken")
         requested_with = request.headers.get("X-Requested-With")
         stored_token = cache.get(f"csrf_token_{request.user.id}")
-        if requested_with == EXPECTED_REQUESTED_WITH:
+        if requested_with == WEBAPP_EXPECTED_REQUESTED_WITH:
             if not csrf_token or csrf_token != stored_token:
                 response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
                 raise HttpError(response)

--- a/core/schema.py
+++ b/core/schema.py
@@ -73,6 +73,7 @@ from core.serializers import InteractiveUserSerializer
 
 MAX_SMALLINT = 32767
 MIN_SMALLINT = -32768
+EXPECTED_REQUESTED_WITH = 'webapp'
 
 core = sys.modules["core"]
 
@@ -278,10 +279,12 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
         request = getattr(info, "context", None)
 
         csrf_token = request.headers.get("X-CSRFToken")
+        requested_with = request.headers.get("X-Requested-With")
         stored_token = cache.get(f"csrf_token_{request.user.id}")
-        if not csrf_token or csrf_token != stored_token:
-            response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
-            raise HttpError(response)
+        if requested_with == EXPECTED_REQUESTED_WITH:
+            if not csrf_token or csrf_token != stored_token:
+                response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
+                raise HttpError(response)
 
         mutation_log = MutationLog.objects.create(
             json_content=json.dumps(data, cls=OpenIMISJSONEncoder),
@@ -522,10 +525,12 @@ class OrderedDjangoFilterConnectionField(DjangoFilterConnectionField):
         request = getattr(info, "context", None)
 
         csrf_token = request.headers.get("X-CSRFToken")
+        requested_with = request.headers.get("X-Requested-With")
         stored_token = cache.get(f"csrf_token_{request.user.id}")
-        if not csrf_token or csrf_token != stored_token:
-            response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
-            raise HttpError(response)
+        if requested_with == EXPECTED_REQUESTED_WITH:
+            if not csrf_token or csrf_token != stored_token:
+                response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
+                raise HttpError(response)
 
         if not info.context.user.is_authenticated:
             raise PermissionDenied(_("unauthorized"))

--- a/core/schema.py
+++ b/core/schema.py
@@ -279,11 +279,12 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
     def mutate_and_get_payload(cls, root, info, **data):
         request = getattr(info, "context", None)
 
-        if CoreConfig.csrf_protect_login:
+        user_agent = request.headers.get("User-Agent", "")
+        if not any(bypass in user_agent for bypass in getattr(settings, "USER_AGENT_CSRF_BYPASS", [])):
             csrf_middleware = CsrfViewMiddleware(lambda req: None)
             reason = csrf_middleware.process_view(request, None, (), {})
             if reason:
-                raise PermissionDenied('CSRF token missing or incorrect.')
+                raise PermissionDenied("CSRF token missing or incorrect.")
 
         mutation_log = MutationLog.objects.create(
             json_content=json.dumps(data, cls=OpenIMISJSONEncoder),
@@ -523,14 +524,15 @@ class OrderedDjangoFilterConnectionField(DjangoFilterConnectionField):
     ):
         request = getattr(info, "context", None)
 
-        if CoreConfig.csrf_protect_login:
+        if not info.context.user.is_authenticated:
+            raise PermissionDenied(_("unauthorized"))
+
+        user_agent = request.headers.get("User-Agent", "")
+        if not any(bypass in user_agent for bypass in getattr(settings, "USER_AGENT_CSRF_BYPASS", [])):
             csrf_middleware = CsrfViewMiddleware(lambda req: None)
             reason = csrf_middleware.process_view(request, None, (), {})
             if reason:
-                raise PermissionDenied('CSRF token missing or incorrect.')
-
-        if not info.context.user.is_authenticated:
-            raise PermissionDenied(_("unauthorized"))
+                raise PermissionDenied("CSRF token missing or incorrect.")
 
         qs = super(DjangoFilterConnectionField, cls).resolve_queryset(
             connection, iterable, info, args

--- a/core/schema.py
+++ b/core/schema.py
@@ -20,6 +20,7 @@ from django.utils.translation import gettext_lazy
 from graphql.error import GraphQLError
 from graphene.types.generic import GenericScalar
 from graphql_jwt.mutations import JSONWebTokenMutation, mixins
+from graphql_jwt.decorators import login_required
 from django.http.response import HttpResponseForbidden
 import graphene_django_optimizer as gql_optimizer
 from graphene_django.views import HttpError
@@ -278,13 +279,11 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
     def mutate_and_get_payload(cls, root, info, **data):
         request = getattr(info, "context", None)
 
-        csrf_token = request.headers.get("X-CSRFToken")
-        requested_with = request.headers.get("X-Requested-With")
-        stored_token = cache.get(f"csrf_token_{request.user.id}")
-        if requested_with == WEBAPP_EXPECTED_REQUESTED_WITH:
-            if not csrf_token or csrf_token != stored_token:
-                response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
-                raise HttpError(response)
+        if CoreConfig.csrf_protect_login:
+            csrf_middleware = CsrfViewMiddleware(lambda req: None)
+            reason = csrf_middleware.process_view(request, None, (), {})
+            if reason:
+                raise PermissionDenied('CSRF token missing or incorrect.')
 
         mutation_log = MutationLog.objects.create(
             json_content=json.dumps(data, cls=OpenIMISJSONEncoder),
@@ -524,13 +523,11 @@ class OrderedDjangoFilterConnectionField(DjangoFilterConnectionField):
     ):
         request = getattr(info, "context", None)
 
-        csrf_token = request.headers.get("X-CSRFToken")
-        requested_with = request.headers.get("X-Requested-With")
-        stored_token = cache.get(f"csrf_token_{request.user.id}")
-        if requested_with == WEBAPP_EXPECTED_REQUESTED_WITH:
-            if not csrf_token or csrf_token != stored_token:
-                response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
-                raise HttpError(response)
+        if CoreConfig.csrf_protect_login:
+            csrf_middleware = CsrfViewMiddleware(lambda req: None)
+            reason = csrf_middleware.process_view(request, None, (), {})
+            if reason:
+                raise PermissionDenied('CSRF token missing or incorrect.')
 
         if not info.context.user.is_authenticated:
             raise PermissionDenied(_("unauthorized"))
@@ -1780,8 +1777,6 @@ class SetPasswordMutation(graphene.relay.ClientIDMutation):
 class OpenimisObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):
     """Obtain JSON Web Token mutation, with auto-provisioning from tblUsers """
 
-    csrf_token = graphene.String()
-
     @classmethod
     def mutate(cls, root, info, **kwargs):
 
@@ -1791,15 +1786,20 @@ class OpenimisObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):
 
         check_lockout(request)
         info.context.user = user_authentication(request, username, password)
+        return super().mutate(cls, info, **kwargs)
 
-        csrf_token = get_token(request)
-        if info.context.user:
-            cache.set(f"csrf_token_{info.context.user.id}", csrf_token, timeout=None)
-        jwt_response = super().mutate(cls, info, **kwargs)
-        jwt_response_data = jwt_response.__dict__
-        jwt_response_data["csrf_token"] = csrf_token
 
-        return cls(**jwt_response_data)
+class GetCsrfTokenMutation(graphene.Mutation):
+    csrf_token = graphene.String()
+
+    @classmethod
+    @login_required
+    def mutate(cls, root, info):
+        csrf_token = get_token(info.context)
+        if not csrf_token:
+            raise GraphQLError("CSRF token could not be generated")
+
+        return GetCsrfTokenMutation(csrf_token=csrf_token)
 
 
 class Mutation(graphene.ObjectType):
@@ -1824,6 +1824,7 @@ class Mutation(graphene.ObjectType):
 
     delete_token_cookie = graphql_jwt.DeleteJSONWebTokenCookie.Field()
     delete_refresh_token_cookie = graphql_jwt.DeleteRefreshTokenCookie.Field()
+    get_csrf_token = GetCsrfTokenMutation.Field()
 
 
 def on_role_mutation(sender, **kwargs):

--- a/core/schema.py
+++ b/core/schema.py
@@ -280,7 +280,9 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
         csrf_token = request.headers.get("X-CSRFToken")
         stored_token = cache.get(f"csrf_token_{request.user.id}")
         if not csrf_token or csrf_token != stored_token:
-            raise HttpError(HttpResponseForbidden((_("Forbidden: Invalid CSRF token."))))
+            response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
+            response.delete_cookie('JWT')
+            raise HttpError(response)
 
         mutation_log = MutationLog.objects.create(
             json_content=json.dumps(data, cls=OpenIMISJSONEncoder),
@@ -523,7 +525,9 @@ class OrderedDjangoFilterConnectionField(DjangoFilterConnectionField):
         csrf_token = request.headers.get("X-CSRFToken")
         stored_token = cache.get(f"csrf_token_{request.user.id}")
         if not csrf_token or csrf_token != stored_token:
-            raise HttpError(HttpResponseForbidden((_("Forbidden: Invalid CSRF token."))))
+            response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
+            response.delete_cookie('JWT')
+            raise HttpError(response)
 
         if not info.context.user.is_authenticated:
             raise PermissionDenied(_("unauthorized"))
@@ -1781,12 +1785,6 @@ class OpenimisObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):
         username = kwargs.get("username")
         password = kwargs.get("password")
         request = info.context
-
-        if CoreConfig.csrf_protect_login:
-            csrf_middleware = CsrfViewMiddleware(lambda req: None)
-            reason = csrf_middleware.process_view(request, None, (), {})
-            if reason:
-                raise PermissionDenied('CSRF token missing or incorrect.')
 
         check_lockout(request)
         info.context.user = user_authentication(request, username, password)

--- a/core/schema.py
+++ b/core/schema.py
@@ -281,7 +281,6 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
         stored_token = cache.get(f"csrf_token_{request.user.id}")
         if not csrf_token or csrf_token != stored_token:
             response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
-            response.delete_cookie('JWT')
             raise HttpError(response)
 
         mutation_log = MutationLog.objects.create(
@@ -526,7 +525,6 @@ class OrderedDjangoFilterConnectionField(DjangoFilterConnectionField):
         stored_token = cache.get(f"csrf_token_{request.user.id}")
         if not csrf_token or csrf_token != stored_token:
             response = HttpResponseForbidden(_("Forbidden: Invalid CSRF token."))
-            response.delete_cookie('JWT')
             raise HttpError(response)
 
         if not info.context.user.is_authenticated:

--- a/core/schema.py
+++ b/core/schema.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 
 import graphene
+from django.http import JsonResponse
 from django.utils.translation import gettext as _
 from copy import copy
 from datetime import datetime as py_datetime
@@ -14,12 +15,14 @@ from graphene_django import DjangoObjectType
 from functools import partial
 from promise import Promise
 
-from functools import reduce
+from functools import reduce, wraps
 from django.utils.translation import gettext_lazy
 from graphql.error import GraphQLError
 from graphene.types.generic import GenericScalar
 from graphql_jwt.mutations import JSONWebTokenMutation, mixins
+from django.http.response import HttpResponseForbidden
 import graphene_django_optimizer as gql_optimizer
+from graphene_django.views import HttpError
 from core.services import (
     create_or_update_interactive_user,
     create_or_update_core_user,
@@ -38,13 +41,13 @@ from django import dispatch
 from django.conf import settings
 from django.core.cache import cache
 from django.contrib.auth.models import AnonymousUser
-from django.core.exceptions import PermissionDenied, ValidationError, PermissionDenied
+from django.core.exceptions import ValidationError, PermissionDenied
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import IntegrityError, transaction
 from django.db.models import Q, Count
 from django.db.models.expressions import RawSQL
 from django.http import HttpRequest
-from django.middleware.csrf import CsrfViewMiddleware
+from django.middleware.csrf import CsrfViewMiddleware, get_token
 from django.utils import translation
 from django.utils.timezone import now
 from graphene.utils.str_converters import to_snake_case, to_camel_case
@@ -272,6 +275,13 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **data):
+        request = getattr(info, "context", None)
+
+        csrf_token = request.headers.get("X-CSRFToken")
+        stored_token = cache.get(f"csrf_token_{request.user.id}")
+        if not csrf_token or csrf_token != stored_token:
+            raise HttpError(HttpResponseForbidden((_("Forbidden: Invalid CSRF token."))))
+
         mutation_log = MutationLog.objects.create(
             json_content=json.dumps(data, cls=OpenIMISJSONEncoder),
             user_id=info.context.user.id if info.context.user else None,
@@ -508,8 +518,16 @@ class OrderedDjangoFilterConnectionField(DjangoFilterConnectionField):
     def resolve_queryset(
             cls, connection, iterable, info, args, filtering_args, filterset_class
     ):
+        request = getattr(info, "context", None)
+
+        csrf_token = request.headers.get("X-CSRFToken")
+        stored_token = cache.get(f"csrf_token_{request.user.id}")
+        if not csrf_token or csrf_token != stored_token:
+            raise HttpError(HttpResponseForbidden((_("Forbidden: Invalid CSRF token."))))
+
         if not info.context.user.is_authenticated:
             raise PermissionDenied(_("unauthorized"))
+
         qs = super(DjangoFilterConnectionField, cls).resolve_queryset(
             connection, iterable, info, args
         )
@@ -1755,6 +1773,8 @@ class SetPasswordMutation(graphene.relay.ClientIDMutation):
 class OpenimisObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):
     """Obtain JSON Web Token mutation, with auto-provisioning from tblUsers """
 
+    csrf_token = graphene.String()
+
     @classmethod
     def mutate(cls, root, info, **kwargs):
 
@@ -1762,15 +1782,17 @@ class OpenimisObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):
         password = kwargs.get("password")
         request = info.context
 
-        if CoreConfig.csrf_protect_login:
-            csrf_middleware = CsrfViewMiddleware(lambda req: None)
-            reason = csrf_middleware.process_view(request, None, (), {})
-            if reason:
-                raise PermissionDenied('CSRF token missing or incorrect.')
-
         check_lockout(request)
         info.context.user = user_authentication(request, username, password)
-        return super().mutate(cls, info, **kwargs)
+
+        csrf_token = get_token(request)
+        if info.context.user:
+            cache.set(f"csrf_token_{info.context.user.id}", csrf_token, timeout=None)
+        jwt_response = super().mutate(cls, info, **kwargs)
+        jwt_response_data = jwt_response.__dict__
+        jwt_response_data["csrf_token"] = csrf_token
+
+        return cls(**jwt_response_data)
 
 
 class Mutation(graphene.ObjectType):


### PR DESCRIPTION
part of: https://openimis.atlassian.net/browse/OS-89

Scope of PR:
- Added new mutation to fetch encoded CSRF for frontend (used on login level)
- Keeping default CSRF Middleware check on gql queries and mutations level
- Added CSRF Agent Bypass, replacing csrf enable/disable by this mechanism

related PR:
- https://github.com/openimis/openimis-be_py/pull/332
- https://github.com/openimis/openimis-be_py/pull/327
- https://github.com/openimis/openimis-fe-core_js/pull/264