### PR TITLE
OP-2485: tied session to the specific session key only, not to the all in csrf check

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -64,7 +64,7 @@ from core.custom_filters import CustomFilterWizardStorage
 from core.gql_queries import RoleGQLType, RoleRightGQLType, UserGQLType, InteractiveUserGQLType, LanguageGQLType, \
     CustomFilterGQLType, ModulePermissionsListGQLType, OfficerGQLType, PermissionOpenImisGQLType, \
     ModulePermissionGQLType, CustomFilterOptionGQLType
-from core.utils import flatten_dict, ExtendedConnection, get_active_superuser_sessions
+from core.utils import flatten_dict, ExtendedConnection, is_this_session_superuser
 from core.models import ModuleConfiguration, FieldControl, MutationLog, Language, RoleMutation, UserMutation, User, \
     InteractiveUser, Role, RoleRight, ClaimAdmin
 from core.services.roleServices import check_role_unique_name
@@ -279,8 +279,8 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
         request = getattr(info, "context", None)
 
         user_agent = request.headers.get("User-Agent", "")
-        superuser_sessions = get_active_superuser_sessions()
-        if len(superuser_sessions) == 0:
+        current_session_key = request.session.session_key
+        if not is_this_session_superuser(current_session_key):
             if not any(bypass in user_agent for bypass in getattr(settings, "USER_AGENT_CSRF_BYPASS", [])):
                 csrf_middleware = CsrfViewMiddleware(lambda req: None)
                 reason = csrf_middleware.process_view(request, None, (), {})
@@ -529,8 +529,8 @@ class OrderedDjangoFilterConnectionField(DjangoFilterConnectionField):
             raise PermissionDenied(_("unauthorized"))
 
         user_agent = request.headers.get("User-Agent", "")
-        superuser_sessions = get_active_superuser_sessions()
-        if len(superuser_sessions) == 0:
+        current_session_key = request.session.session_key
+        if not is_this_session_superuser(current_session_key):
             if not any(bypass in user_agent for bypass in getattr(settings, "USER_AGENT_CSRF_BYPASS", [])):
                 csrf_middleware = CsrfViewMiddleware(lambda req: None)
                 reason = csrf_middleware.process_view(request, None, (), {})

--- a/core/utils.py
+++ b/core/utils.py
@@ -586,23 +586,22 @@ def get_cache_key(model, id):
     return f"cs_{model.__name__}_{id}"
 
 
-def get_active_superuser_sessions():
-    active_superusers = []
-
+def is_this_session_superuser(session_key):
     from django.contrib.sessions.models import Session
     from django.utils.timezone import now
-    sessions = Session.objects.filter(expire_date__gte=now())
+    from core.models import User
 
-    for session in sessions:
-        try:
-            data = session.get_decoded()
-            user_id = data.get('_auth_user_id')
-            if user_id:
-                from core.models import User
-                user = User.objects.get(id=user_id)
-                if user.is_superuser:
-                    active_superusers.append(user)
-        except Exception as e:
-            pass
+    try:
+        session = Session.objects.get(session_key=session_key, expire_date__gte=now())
+        data = session.get_decoded()
+        user_id = data.get('_auth_user_id')
+        if user_id:
+            user = User.objects.get(id=user_id)
+            if user.is_superuser:
+                return True
+    except Session.DoesNotExist:
+        pass
+    except Exception as e:
+        pass
 
-    return active_superusers
+    return False


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-2485

Previously sessions in csrf check are checked globally. It must be checked only to the specific session key. 