### PR TITLE
OICI-143: New multilingual solution for displaying roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The auto-provisioning assigns a default Group (name can be parameterized) from w
 Note: if not existing, the default group is created at startup.
 
 ### Language Support for Role Labels
-If the user has a language different from the system default and a translation is available in alt_language, the role name is returned in that language. Otherwise, it falls back to the default name. This ensures localized role labels are shown based on the user's language preferences.
+Role names are displayed in the user's selected language using Django's translation system with .po and .mo files. If a translation is available for the user's language (e.g., fr), the translated role name is shown. Otherwise, it falls back to the default role name. This ensures localized role labels are displayed based on the user's language preferences, managed through translation files rather than a database column.
 
 ### Mutations & Signals
 The OpenIMISMutation class of this module provides the template code for

--- a/core/gql_queries.py
+++ b/core/gql_queries.py
@@ -6,8 +6,7 @@ from graphene_django import DjangoObjectType
 from location.models import HealthFacility
 from core.apps import CoreConfig
 from django.utils.translation import gettext as _
-from django.core.exceptions import PermissionDenied
-from core.utils import get_first_or_default_language
+from django.core.exceptions import PermissionDenied 
 
 from .utils import prefix_filterset
 
@@ -52,10 +51,7 @@ class RoleGQLType(DjangoObjectType):
         connection_class = ExtendedConnection
         
     def resolve_name(self, info):
-        defaut_language = get_first_or_default_language().code
-        user = info.context.user
-        user_language = getattr(user.i_user, 'language_id', defaut_language) if user.i_user else defaut_language
-        return self.get_display_name(user_language=user_language)
+        return _(self.name)
 
     @classmethod
     def get_queryset(cls, queryset, info):

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -22,8 +22,7 @@ from django.conf import settings
 from ..utils import filter_validity
 from .base import *
 from .versioned_model import *
-from core.utils import get_first_or_default_language
-
+ 
 logger = logging.getLogger(__name__)
 from rest_framework import exceptions
 
@@ -130,15 +129,7 @@ class Role(VersionedModel):
     is_blocked = models.BooleanField(db_column='IsBlocked')
     audit_user_id = models.IntegerField(
         db_column='AuditUserID', blank=True, null=True)
-    
-    def get_display_name(self, user_language=None):
-        """
-        Returns the role name in the user's language if available, otherwise falls back to the default name.
-        """
-        defaut_language = get_first_or_default_language().code
-        if user_language and self.alt_language and user_language != defaut_language:
-            return self.alt_language
-        return self.name
+
 
     def natural_key(self):
         return (self.uuid,)

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -134,3 +134,45 @@ msgstr ""
 #: core/views.py:38
 msgid "Only user requesting export can fetch request"
 msgstr ""
+
+msgid "Enrolment Officer"
+msgstr "Enrolment Officer"
+
+msgid "Manager"
+msgstr "Manager"
+
+msgid "Accountant"
+msgstr "Accountant"
+
+msgid "Clerk"
+msgstr "Clerk"
+
+msgid "Medical Officer"
+msgstr "Medical Officer"
+
+msgid "Scheme Administrator"
+msgstr "Scheme Administrator"
+
+msgid "IMIS Administrator"
+msgstr "IMIS Administrator"
+
+msgid "Receptionist"
+msgstr "Receptionist"
+
+msgid "Claim Administrator"
+msgstr "Claim Administrator"
+
+msgid "Claim Contributor"
+msgstr "Claim Contributor"
+
+msgid "HF Administrator"
+msgstr "HF Administrator"
+
+msgid "Offline Administrator"
+msgstr "Offline Administrator"
+
+msgid "Schema Admin"
+msgstr "Schema Admin"
+
+msgid "Task Triage"
+msgstr "Task Triage"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,54 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: lokalise.com\n"
+"Project-Id-Version: openIMIS-be\n"
+"PO-Revision-Date: 2020-11-23 16:26\n"
+"Last-Translator: lokalise.com\n"
+"Language-Team: lokalise.com\n\n"
+"Language: fr\n"
+
+
+msgid "Enrolment Officer"
+msgstr "Agent d'inscription numero 1"
+
+msgid "Manager"
+msgstr "Gestionnaire"
+
+msgid "Accountant"
+msgstr "Comptable"
+
+msgid "Clerk"
+msgstr "Employé de bureau"
+
+msgid "Medical Officer"
+msgstr "Officier médical"
+
+msgid "Scheme Administrator"
+msgstr "Administrateur de régime"
+
+msgid "IMIS Administrator"
+msgstr "Administrateur IMIS"
+
+msgid "Receptionist"
+msgstr "Réceptionniste"
+
+msgid "Claim Administrator"
+msgstr "Administrateur des réclamations"
+
+msgid "Claim Contributor"
+msgstr "Contributeur aux réclamations"
+
+msgid "HF Administrator"
+msgstr "Administrateur d'établissement de santé"
+
+msgid "Offline Administrator"
+msgstr "Administrateur hors ligne"
+
+msgid "Schema Admin"
+msgstr "Administrateur de schéma"
+
+msgid "Task Triage"
+msgstr "Triage des tâches"


### PR DESCRIPTION
The role management interface is not displaying role names in the language selected by the user. Specifically, when the interface is set to French, the roles are shown in the default language instead of the user's selected language.

This suggests that the column Alternative Language in the role definition table is not being properly used to load the localized role labels based on the user's language.

**Expected Behavior:**
Role names should be shown in the current user's language (e.g., fr_KM if selected).

The system should fetch and display role labels from the Alternative Language column according to the current locale.

If no translation exists, it can fall back to the default, but not when a translation is available.