### PR TITLE
feat: support custom filter reloading

### DIFF
--- a/core/custom_filters/custom_filter_registry_point.py
+++ b/core/custom_filters/custom_filter_registry_point.py
@@ -63,7 +63,14 @@ class CustomFilterRegistryPoint:
     ) -> None:
         if module_name not in cls.REGISTERED_CUSTOM_FILTER_WIZARDS:
             cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"] = []
-        cls.REGISTERED_CUSTOM_FILTER_WIZARDS[f"{module_name}"].append({
+
+        # Remove any existing entries with the same class name to support reload
+        cls.REGISTERED_CUSTOM_FILTER_WIZARDS[module_name] = [
+            entry for entry in cls.REGISTERED_CUSTOM_FILTER_WIZARDS[module_name]
+            if entry["class_reference"].__name__ != custom_filter_class.__name__
+        ]
+
+        cls.REGISTERED_CUSTOM_FILTER_WIZARDS[module_name].append({
             "class_reference": custom_filter_class,
             "module": module_name
         })

--- a/core/tests/test_custom_filters.py
+++ b/core/tests/test_custom_filters.py
@@ -1,0 +1,57 @@
+import unittest
+from core.custom_filters import CustomFilterWizardInterface, CustomFilterRegistryPoint  
+
+
+class DummyCustomFilterA(CustomFilterWizardInterface):
+    pass
+
+
+class DummyCustomFilterB(CustomFilterWizardInterface):
+    pass
+
+
+class TestCustomFilterRegistryPoint(unittest.TestCase):
+
+    def setUp(self):
+        # Clear registry before each test
+        CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS.clear()
+
+    def test_register_single_filter(self):
+        CustomFilterRegistryPoint.register_custom_filters("test_module", [DummyCustomFilterA])
+
+        registered = CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS
+        self.assertIn("test_module", registered)
+        self.assertEqual(len(registered["test_module"]), 1)
+        self.assertEqual(registered["test_module"][0]["class_reference"], DummyCustomFilterA)
+
+    def test_register_multiple_filters(self):
+        CustomFilterRegistryPoint.register_custom_filters("test_module", [DummyCustomFilterA, DummyCustomFilterB])
+
+        registered = CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS["test_module"]
+        self.assertEqual(len(registered), 2)
+        self.assertCountEqual(
+            [entry["class_reference"] for entry in registered],
+            [DummyCustomFilterA, DummyCustomFilterB]
+        )
+
+    def test_register_overwrites_duplicate_class(self):
+        # First registration
+        CustomFilterRegistryPoint.register_custom_filters("test_module", [DummyCustomFilterA])
+        # Simulate re-registering DummyCustomFilterA (e.g., on reload)
+        CustomFilterRegistryPoint.register_custom_filters("test_module", [DummyCustomFilterA])
+
+        registered = CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS["test_module"]
+        self.assertEqual(len(registered), 1)
+        self.assertEqual(registered[0]["class_reference"], DummyCustomFilterA)
+
+    def test_register_same_class_in_different_modules(self):
+        CustomFilterRegistryPoint.register_custom_filters("module_a", [DummyCustomFilterA])
+        CustomFilterRegistryPoint.register_custom_filters("module_b", [DummyCustomFilterA])
+
+        registered = CustomFilterRegistryPoint.REGISTERED_CUSTOM_FILTER_WIZARDS
+        self.assertIn("module_a", registered)
+        self.assertIn("module_b", registered)
+        self.assertEqual(len(registered["module_a"]), 1)
+        self.assertEqual(len(registered["module_b"]), 1)
+        self.assertEqual(registered["module_a"][0]["module"], "module_a")
+        self.assertEqual(registered["module_b"][0]["module"], "module_b")


### PR DESCRIPTION
Currently creating/editing individual schema in django admin requires restarting of the server for the change to take effect. This change is required to allow dynamic reloading of individual schema upon update without restarting the server. Individual module changes to follow.