### PR TITLE
fix: fix validity_to on core_user #OICI-187

### DIFF
--- a/core/services/userServices.py
+++ b/core/services/userServices.py
@@ -216,6 +216,12 @@ def create_or_update_core_user(user_uuid, username, i_user=None, t_user=None, of
         user = None
         created = False
 
+    if user and user.i_user and i_user:
+        if user.i_user != i_user:
+            from core import datetime
+            now = datetime.datetime.now()
+            user.validity_from = now
+            user.validity_to = None
     if not user:
         user = User(username=username)
         created = True


### PR DESCRIPTION
When a user is deleted, the validityTo field is correctly updated in both the core_user and tblUsers tables.

However, if a user with the same name is recreated afterward, the system reuses the old record from the core_user table without updating its validityTo field.

This leads to an inconsistency: the frontend displays a user whose validity date does not match the new instance, as it reads the outdated value via GraphQL.