### PR TITLE
feat: remove validity_from/to from User and Interactive user models

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -17,7 +17,7 @@ class TechnicalUserForm(forms.ModelForm):
 
     class Meta:
         model = TechnicalUser
-        fields = ["username", "email", "is_superuser", "validity_from", "validity_to"]
+        fields = ["username", "email", "is_superuser"]
 
     def save(self, commit=True):
         user = super().save(commit=False)

--- a/core/migrations/0035_remove_technicaluser_validity_from_and_more.py
+++ b/core/migrations/0035_remove_technicaluser_validity_from_and_more.py
@@ -1,0 +1,35 @@
+# Generated manually
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0034_remove_user_legacy_id_remove_user_validity_from_and_more'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='technicaluser',
+            name='validity_from',
+        ),
+        migrations.RemoveField(
+            model_name='technicaluser',
+            name='validity_to',
+        ),
+        migrations.RemoveField(
+            model_name='interactiveuser',
+            name='validity_from',
+        ),
+        migrations.RemoveField(
+            model_name='interactiveuser',
+            name='validity_to',
+        ),
+        migrations.RemoveField(
+            model_name='historicalinteractiveuser',
+            name='validity_from',
+        ),
+        migrations.RemoveField(
+            model_name='historicalinteractiveuser',
+            name='validity_to',
+        ),
+    ]

--- a/core/models/openimis_model.py
+++ b/core/models/openimis_model.py
@@ -158,10 +158,12 @@ class OpenIMISHistoryMixin(DirtyFieldsMixin, CachedModelMixin, Model):
     @staticmethod
     def filter_validity(arg="validity", prefix="", **kwargs):
         validity = kwargs.get(arg, None)
+        active_key = f"{prefix}active"
+        deactivated_key = f"{prefix}date_deactivated__gte"
         if not validity:
-            return Q(active=True)
+            return [Q(**{active_key: True})]
         else:
-            return Q(active=False) | Q(date_deactivated__gte=validity)
+            return [Q(**{active_key: False}) | Q(**{deactivated_key: validity})]
 
     class Meta:
         abstract = True

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -95,7 +95,6 @@ class TechnicalUser(AbstractBaseUser):
     language = "en"
     is_staff = models.BooleanField(default=False)
     is_superuser = models.BooleanField(default=False)
-    is_superuser = models.BooleanField(default=False)
     is_imis_admin = False
 
     @property

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -23,7 +23,7 @@ from django.contrib.auth.password_validation import validate_password
 from ..utils import CachedManager
 from .base import ExtendableModel, Language, UUIDModel
 from .versioned_model import VersionedModel
-from .openimis_model import OpenIMISMigrationModel, OpenIMISHistoryMixin  # , OpenIMISModel
+from .openimis_model import OpenIMISHistoryMixin, OpenIMISModel
 from core.utils import to_list_permissions
 from rest_framework import exceptions
 
@@ -95,8 +95,7 @@ class TechnicalUser(AbstractBaseUser):
     language = "en"
     is_staff = models.BooleanField(default=False)
     is_superuser = models.BooleanField(default=False)
-    validity_from = models.DateTimeField(blank=True, null=True, default=py_datetime.now)
-    validity_to = models.DateTimeField(blank=True, null=True)
+    is_superuser = models.BooleanField(default=False)
     is_imis_admin = False
 
     @property
@@ -191,7 +190,7 @@ class RoleRight(VersionedModel):
         db_table = "tblRoleRight"
 
 
-class InteractiveUser(OpenIMISMigrationModel):
+class InteractiveUser(OpenIMISModel):
     UNIQUE_FIELDS = {"pk", "uuid", "id", "login_name"}
     USE_CACHE = not settings.IS_TESTING
     # id = models.AutoField(db_column="UserID", primary_key=True)
@@ -345,7 +344,7 @@ class InteractiveUser(OpenIMISMigrationModel):
                 user_roles__user=self,
                 validity_to__isnull=True,
                 user_roles__validity_to__isnull=True,
-                user_roles__user__validity_to__isnull=True,
+                user_roles__user__active=True,
             ).exists()
             cache.set("is_admin_" + str(self.id), is_admin, 600)
         return is_admin
@@ -659,8 +658,7 @@ class User(UUIDModel, OpenIMISHistoryMixin, PermissionsMixin):
 
     @staticmethod
     def filter_validity(arg="validity", prefix="", **kwargs):
-        return {}
-        return {}
+        return []
 
     def check_password(self, *args, **kwargs):
         if self._u:
@@ -672,10 +670,6 @@ class User(UUIDModel, OpenIMISHistoryMixin, PermissionsMixin):
         pass
 
     def delete_history(self, **kwargs):
-        # now = py_datetime.now()
-        # self.validity_from = now
-        # self.validity_to = now
-        # self.save()
         pass
 
     @property
@@ -737,15 +731,7 @@ class User(UUIDModel, OpenIMISHistoryMixin, PermissionsMixin):
     def is_active(self):
         if self.i_user:
             return self.i_user.active
-        else:
-            if self._u.validity_from is None and self._u.validity_to is None:
-                return True
-            now = py_datetime.now()
-            if self._u.validity_from is not None and self._u.validity_from > now:
-                return False
-            if self._u.validity_to is not None and self._u.validity_to < now:
-                return False
-            return True
+        return True
 
     def has_perm(self, perm, obj=None):
         i_user = self.i_user if obj is None else obj.i_user

--- a/core/schema.py
+++ b/core/schema.py
@@ -959,7 +959,7 @@ class Query(graphene.ObjectType):
         if not info.context.user.has_perms(CoreConfig.gql_query_users_perms):
             raise PermissionDenied(_("unauthorized"))
         if User.objects.filter(
-            username=kwargs["username"], validity_to__isnull=True
+            username=kwargs["username"]
         ).exists():
             return False
         else:
@@ -1097,7 +1097,7 @@ class Query(graphene.ObjectType):
         if not show_deleted and not kwargs.get("id", None):
             # active_users_ids = [user.id for user in user_query if user.active]
             user_filters.append(
-                Q(i_user__isnull=True) | Q(*User.filter_validity(prefix="i_user__"))
+                Q(i_user__isnull=True) | Q(*InteractiveUser.filter_validity(prefix="i_user__"))
             )
 
         text_search = kwargs.get("str")  # Poorly chosen name, avoid of shadowing "str"

--- a/core/services/userServices.py
+++ b/core/services/userServices.py
@@ -39,13 +39,13 @@ def create_or_update_interactive_user(user_id, data, user_maker, connected):
     if user_id:
         # TODO we might want to update a user that has been deleted. Use Legacy ID ?
         i_user = InteractiveUser.objects.filter(
-            validity_to__isnull=True, user__id=user_id
+            active=True, user__id=user_id
         ).first()
-        if i_user.validity_to is not None and i_user.validity_to:
+        if i_user and not i_user.active:
             raise ValidationError(_("core.user.edit_historical_data_error"))
     else:
         i_user = InteractiveUser.objects.filter(
-            validity_to__isnull=True, login_name=data_subset["login_name"]
+            active=True, login_name=data_subset["login_name"]
         ).first()
     if i_user:
         i_user.save_history()
@@ -300,7 +300,7 @@ def user_authentication(request, username, password):
 
 def check_user_unique_email(user_email):
     if InteractiveUser.objects.filter(
-        email=user_email, validity_to__isnull=True
+        email=user_email, active=True
     ).exists():
         return [{"message": "User email %s already exists" % user_email}]
     return []

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -13,26 +13,6 @@ class UserTestCase(TestCase):
         )
         self.assertTrue(always_valid.is_active)
 
-        import datetime
-
-        not_yet_active = User(
-            username="not_yet_active",
-            t_user=TechnicalUser(
-                username="not_yet_active",
-                validity_from=datetime.datetime.now() + datetime.timedelta(days=1),
-            ),
-        )
-        self.assertFalse(not_yet_active.is_active)
-
-        not_active_anymore = User(
-            username="not_active_anymore",
-            t_user=TechnicalUser(
-                username="not_active_anymore",
-                validity_to=datetime.datetime.now() + datetime.timedelta(days=-1),
-            ),
-        )
-        self.assertFalse(not_active_anymore.is_active)
-
     def test_interactive_user_bulk_operations_and_cache(self):
         """Test InteractiveUser.objects.bulk_create and bulk_update with cache functionality"""
         # Clear cache to ensure clean state


### PR DESCRIPTION
# Description

- Remove validity_from and validity_to from TechnicalUser and InteractiveUser
- Update InteractiveUser to inherit from OpenIMISModel
- Fix FieldError in users query and JWT authentication by updating filter_validity logic
- Update forms and tests to align with the new model structure
- Add migration 0035 for schema changes

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
