### PR TITLE
Fix: empty user query result and module CI & add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,7 @@ This repository holds the files of the openIMIS Backend Core reference module.
 It is a required module of [openimis-be_py](https://github.com/openimis/openimis-be_py).
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-
-## Code climate (develop branch)
-
-[![Maintainability](https://img.shields.io/codeclimate/maintainability/openimis/openimis-be-core_py.svg)](https://codeclimate.com/github/openimis/openimis-be-core_py/maintainability)
-[![Test Coverage](https://img.shields.io/codeclimate/coverage/openimis/openimis-be-core_py.svg)](https://codeclimate.com/github/openimis/openimis-be-core_py)
-
-## LGTM
-
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/openimis/openimis-be-core_py.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/openimis/openimis-be-core_py/alerts/)
+[![CI](https://github.com/openimis/openimis-be-core_py/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/openimis/openimis-be-core_py/actions/workflows/ci.yml?query=branch%3Adevelop)
 
 ## ORM mapping:
 * UUIDModel: abstract model for new entities (and later on migrated entities), enforcing the use of UUID is identifier

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -663,8 +663,6 @@ class User(UUIDModel, OpenIMISHistoryMixin, PermissionsMixin):
 
     @staticmethod
     def filter_validity(arg="validity", prefix="", **kwargs):
-        if prefix:
-            return core_filter_validity(arg, prefix, **kwargs)
         return []
 
     def check_password(self, *args, **kwargs):

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -24,7 +24,7 @@ from ..utils import CachedManager
 from .base import ExtendableModel, Language, UUIDModel
 from .versioned_model import VersionedModel
 from .openimis_model import OpenIMISMigrationModel, OpenIMISHistoryMixin  # , OpenIMISModel
-from core.utils import to_list_permissions
+from core.utils import to_list_permissions, filter_validity as core_filter_validity
 from rest_framework import exceptions
 
 logger = logging.getLogger(__name__)
@@ -659,8 +659,9 @@ class User(UUIDModel, OpenIMISHistoryMixin, PermissionsMixin):
 
     @staticmethod
     def filter_validity(arg="validity", prefix="", **kwargs):
-        return {}
-        return {}
+        if prefix:
+            return core_filter_validity(arg, prefix, **kwargs)
+        return []
 
     def check_password(self, *args, **kwargs):
         if self._u:

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -24,7 +24,7 @@ from ..utils import CachedManager
 from .base import ExtendableModel, Language, UUIDModel
 from .versioned_model import VersionedModel
 from .openimis_model import OpenIMISMigrationModel, OpenIMISHistoryMixin  # , OpenIMISModel
-from core.utils import to_list_permissions, filter_validity as core_filter_validity
+from core.utils import to_list_permissions
 from rest_framework import exceptions
 
 logger = logging.getLogger(__name__)

--- a/core/schema.py
+++ b/core/schema.py
@@ -1991,7 +1991,7 @@ def change_user_language(user, language_id):
             user__id=user.id, *InteractiveUser.filter_validity()
         ).first()
         updated_user.language_id = language_id
-        updated_user.save()
+        updated_user.save(user=user)
     except Exception as exc:
         logger.error(
             "[OpenIMISMutation] Failed to change user language for user %s: %s",

--- a/core/test_helpers.py
+++ b/core/test_helpers.py
@@ -362,7 +362,7 @@ def create_claim_admin_role():
     return create_test_role(perm_names=claim_admin_perms, name="ClaimAdministrator", is_system=16)
 
 
-def create_test_role(perm_names, name=None, is_system=0, is_blocked=False, custom_props=None):
+def create_test_role(perm_names=[], name=None, is_system=0, is_blocked=False, custom_props=None):
     """
     Create a test role with permissions specified by name as they appear in the module DEFAULT config.
 

--- a/core/tests/test_graphql.py
+++ b/core/tests/test_graphql.py
@@ -228,6 +228,39 @@ class gqlTest(openIMISGraphQLTestCase):
         )
         self.assertResponseNoErrors(response)
 
+    def test_users_query_returns_interactive_users(self):
+        """Test that the users query returns users with interactive user links (i_user)."""
+        query = """
+            {
+                users(first: 10, orderBy: ["username"]) {
+                    totalCount
+                    edges {
+                        node {
+                            id
+                            username
+                        }
+                    }
+                }
+            }
+        """
+        response = self.query(
+            query, headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
+        )
+        self.assertResponseNoErrors(response)
+        content = json.loads(response.content)
+        users_data = content["data"]["users"]
+        self.assertGreater(
+            users_data["totalCount"],
+            0,
+            "Users query should return at least one user (the admin user)"
+        )
+        usernames = [edge["node"]["username"] for edge in users_data["edges"]]
+        self.assertIn(
+            self.admin_username,
+            usernames,
+            f"Admin user '{self.admin_username}' should be in the returned users"
+        )
+
     def test_user_modification_creates_history_with_user(self):
         """Test that user modification via GraphQL creates history record with user included for audit"""
         # Get initial history count for the admin user

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -19,7 +19,7 @@ from location.models import OfficerVillage
 from location.test_helpers import create_test_village, create_test_health_facility
 from core.test_helpers import (
     create_test_interactive_user,
-    create_admin_role,
+    create_test_role,
 )
 logger = logging.getLogger(__file__)
 PASSWORD = "FoBoar72!"
@@ -52,8 +52,8 @@ class UserServicesTest(TestCase):
         self.user = create_test_interactive_user()
 
     def test_create_iuser_required_fields_only(self):
-        admin_role_id = create_admin_role().id
-        roles = [admin_role_id]
+        role_id = create_test_role().id
+        roles = [role_id]
         username = "tstsvciu1"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -73,11 +73,11 @@ class UserServicesTest(TestCase):
         self.assertEqual(i_user.last_name, "Last Name CIU1")
         self.assertEqual(i_user.other_names, "Other 1 2 3")
         self.assertEqual(i_user.user_roles.count(), 1)
-        self.assertEqual(i_user.user_roles.first().role_id, admin_role_id)
+        self.assertEqual(i_user.user_roles.first().role_id, role_id)
         self.assertEqual(i_user.language.code, "en")
 
     def test_create_iuser_with_optional_fields(self):
-        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
+        roles = [create_test_role(name="TestRole1").id, create_test_role(name="TestRole2").id]
         username = "tstsvciu2"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -113,8 +113,8 @@ class UserServicesTest(TestCase):
         self.assertFalse(i_user.check_password("wrong_password"))
 
     def test_iuser_update(self):
-        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
-        roles2 = [create_admin_role("TestRole3").id, create_admin_role("TestRole4").id]
+        roles = [create_test_role(name="TestRole1").id, create_test_role(name="TestRole2").id]
+        roles2 = [create_test_role(name="TestRole3").id, create_test_role(name="TestRole4").id]
         username = "tstsvciu2"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -192,7 +192,7 @@ class UserServicesTest(TestCase):
         """
         This tests the update of a user without specifying a userId but with a username
         """
-        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
+        roles = [create_test_role(name="TestRole1").id, create_test_role(name="TestRole2").id]
         username = "tstsvciu3"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -430,7 +430,7 @@ class UserServicesTest(TestCase):
     def test_user_reset_password(self):
         from django.core import mail
 
-        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
+        roles = [create_test_role(name="TestRole1").id, create_test_role(name="TestRole2").id]
         username = "user_reset"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -463,7 +463,7 @@ class UserServicesTest(TestCase):
         self.assertTrue(mail.outbox[0].subject == "[OpenIMIS] Reset Password")
 
     def test_user_set_password(self):
-        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
+        roles = [create_test_role(name="TestRole1").id, create_test_role(name="TestRole2").id]
         username = "user_set"
         i_user, created = create_or_update_interactive_user(
             user_id=None,

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -1,12 +1,11 @@
 import importlib
 import logging
+import datetime
 
-from django.db import connection
 from django.test.client import RequestFactory
 from django.apps import apps
-import datetime
 import core
-from core.models import InteractiveUser, Officer, UserRole, Language
+from core.models import Language
 from core.services import (
     create_or_update_interactive_user,
     create_or_update_core_user,
@@ -23,7 +22,6 @@ from core.test_helpers import (
     create_admin_role,
 )
 logger = logging.getLogger(__file__)
-postgresql = "postgresql"
 PASSWORD = "FoBoar72!"
 
 
@@ -386,7 +384,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(officer2.phone, "+00000")
         self.assertEqual(officer2.email, "imis@bar.be")
 
-
     def test_claim_admin_min(self):
         username = "tstsvca1"
         claim_admin, created = create_or_update_claim_admin(
@@ -402,7 +399,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(claim_admin.username, username)
         self.assertEqual(claim_admin.last_name, "Last Name CA1")
         self.assertEqual(claim_admin.other_names, "Other 1 2 3")
-
 
     def test_claim_admin_max(self):
         username = "tstsvca2"
@@ -430,7 +426,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(claim_admin.health_facility_id, self.test_hf.id)
         self.assertEqual(claim_admin.phone, "+12345678")
         self.assertEqual(claim_admin.email_id, "imis@foo.be")
-
 
     def test_user_reset_password(self):
         from django.core import mail

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -78,10 +78,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(i_user.user_roles.first().role_id, admin_role_id)
         self.assertEqual(i_user.language.code, "en")
 
-        UserRole.objects.filter(user_id=i_user.id).delete()
-        deleted_users = InteractiveUser.objects.filter(login_name=username).delete()
-        logger.info(f"Deleted {deleted_users} users after test")
-
     def test_create_iuser_with_optional_fields(self):
         roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
         username = "tstsvciu2"
@@ -117,10 +113,6 @@ class UserServicesTest(TestCase):
         self.assertNotEqual(i_user.password, PASSWORD)  # No clear text password
         self.assertTrue(i_user.check_password(PASSWORD))
         self.assertFalse(i_user.check_password("wrong_password"))
-
-        UserRole.objects.filter(user_id=i_user.id).delete()
-        deleted_users = InteractiveUser.objects.filter(login_name=username).delete()
-        logger.info(f"Deleted {deleted_users} users after test")
 
     def test_iuser_update(self):
         roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
@@ -198,11 +190,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(i_user2.email, f"{username}@updated.int")
         self.assertTrue(i_user2.check_password(f"{PASSWORD}updated"))
 
-        UserRole.objects.filter(user_id=i_user.id).delete()
-        core_user.delete()
-        deleted_users = InteractiveUser.objects.filter(login_name=username).delete()
-        logger.info(f"Deleted {deleted_users} users after test")
-
     def test_iuser_update_no_id(self):
         """
         This tests the update of a user without specifying a userId but with a username
@@ -243,10 +230,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(i_user2.last_name, "Last updated")
         self.assertEqual(i_user2.other_names, "Other updated")
 
-        UserRole.objects.filter(user_id=i_user.id).delete()
-        deleted_users = InteractiveUser.objects.filter(login_name=username).delete()
-        logger.info(f"Deleted {deleted_users} users after test")
-
     def test_officer_min(self):
         username = "tstsvco1"
         officer, created = create_or_update_officer(
@@ -266,9 +249,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(officer.last_name, "Last Name O1")
         self.assertEqual(officer.other_names, "Other 1 2 3")
         self.assertEqual(officer.phone, "+12345678")
-
-        deleted_officers = Officer.objects.filter(code=username).delete()
-        logger.info(f"Deleted {deleted_officers} officers after test")
 
     def test_officer_max(self):
         username = "tstsvco2"
@@ -315,9 +295,6 @@ class UserServicesTest(TestCase):
         )
         self.assertEqual(officer.phone, "+12345678")
         self.assertEqual(officer.email, "imis@foo.be")
-
-        deleted_officers = Officer.objects.filter(code=username).delete()
-        logger.info(f"Deleted {deleted_officers} officers after test")
 
     def test_officer_update(self):
         username = "tstsvco2"
@@ -409,8 +386,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(officer2.phone, "+00000")
         self.assertEqual(officer2.email, "imis@bar.be")
 
-        deleted_officers = Officer.objects.filter(code=username).delete()
-        logger.info(f"Deleted {deleted_officers} officers after test")
 
     def test_claim_admin_min(self):
         username = "tstsvca1"
@@ -428,8 +403,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(claim_admin.last_name, "Last Name CA1")
         self.assertEqual(claim_admin.other_names, "Other 1 2 3")
 
-        deleted_officers = Officer.objects.filter(code=username).delete()
-        logger.info(f"Deleted {deleted_officers} officers after test")
 
     def test_claim_admin_max(self):
         username = "tstsvca2"
@@ -458,8 +431,6 @@ class UserServicesTest(TestCase):
         self.assertEqual(claim_admin.phone, "+12345678")
         self.assertEqual(claim_admin.email_id, "imis@foo.be")
 
-        deleted_officers = Officer.objects.filter(code=username).delete()
-        logger.info(f"Deleted {deleted_officers} officers after test")
 
     def test_user_reset_password(self):
         from django.core import mail
@@ -496,12 +467,6 @@ class UserServicesTest(TestCase):
         self.assertTrue(len(mail.outbox) == 1)
         self.assertTrue(mail.outbox[0].subject == "[OpenIMIS] Reset Password")
 
-        UserRole.objects.filter(user_id=i_user.id).delete()
-        if connection.vendor == postgresql:
-            UserRole.objects.filter(user_id=core_user.id).delete()
-        core_user.delete()
-        i_user.delete()
-
     def test_user_set_password(self):
         roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
         username = "user_set"
@@ -531,9 +496,3 @@ class UserServicesTest(TestCase):
         request = self.factory.get("/")
         with self.assertRaises(ValidationError):
             set_user_password(request, username, "TOKEN", "new_password")
-
-        UserRole.objects.filter(user_id=i_user.id).delete()
-        if connection.vendor == postgresql:
-            UserRole.objects.filter(user_id=core_user.id).delete()
-        core_user.delete()
-        i_user.delete()

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -20,10 +20,6 @@ from location.models import OfficerVillage
 from location.test_helpers import create_test_village, create_test_health_facility
 from core.test_helpers import (
     create_test_interactive_user,
-    create_manager_role,
-    create_enrolment_officer_role,
-    create_claim_admin_role,
-    create_accountant_role,
     create_admin_role,
 )
 logger = logging.getLogger(__file__)
@@ -57,7 +53,7 @@ class UserServicesTest(TestCase):
         self.test_hf2 = create_test_health_facility()
         self.user = create_test_interactive_user()
 
-    def test_iuser_min(self):
+    def test_create_iuser_required_fields_only(self):
         admin_role_id = create_admin_role().id
         roles = [admin_role_id]
         username = "tstsvciu1"
@@ -86,8 +82,8 @@ class UserServicesTest(TestCase):
         deleted_users = InteractiveUser.objects.filter(login_name=username).delete()
         logger.info(f"Deleted {deleted_users} users after test")
 
-    def test_iuser_max(self):
-        roles = [create_manager_role().id, create_enrolment_officer_role().id]
+    def test_create_iuser_with_optional_fields(self):
+        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
         username = "tstsvciu2"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -127,8 +123,8 @@ class UserServicesTest(TestCase):
         logger.info(f"Deleted {deleted_users} users after test")
 
     def test_iuser_update(self):
-        roles = [create_manager_role().id, create_enrolment_officer_role().id]
-        roles2 = [create_accountant_role().id, create_claim_admin_role().id]
+        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
+        roles2 = [create_admin_role("TestRole3").id, create_admin_role("TestRole4").id]
         username = "tstsvciu2"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -211,7 +207,7 @@ class UserServicesTest(TestCase):
         """
         This tests the update of a user without specifying a userId but with a username
         """
-        roles = [create_manager_role().id, create_enrolment_officer_role().id]
+        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
         username = "tstsvciu3"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -468,7 +464,7 @@ class UserServicesTest(TestCase):
     def test_user_reset_password(self):
         from django.core import mail
 
-        roles = [create_manager_role().id, create_enrolment_officer_role().id]
+        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
         username = "user_reset"
         i_user, created = create_or_update_interactive_user(
             user_id=None,
@@ -507,7 +503,7 @@ class UserServicesTest(TestCase):
         i_user.delete()
 
     def test_user_set_password(self):
-        roles = [create_manager_role().id, create_enrolment_officer_role().id]
+        roles = [create_admin_role("TestRole1").id, create_admin_role("TestRole2").id]
         username = "user_set"
         i_user, created = create_or_update_interactive_user(
             user_id=None,


### PR DESCRIPTION
# Description

- Fix user query returning empty results due to incorrectly implemented `filter_validity`. Added regression tests.
- Fix broken module CI
- Remove unnecessary external module dependencies from core unit tests (e.g. gql_query_policies_perms, gql_query_products_perms, gql_query_insuree_perms required for create_enrolment_officer_role)
- Remove unnecessary manual test data cleanup. Django's TestCase will take care of if, even with --keepdb
- Add module CI status badge to README, replacing non-functional badges

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

before:
<img width="1600" height="1015" alt="image" src="https://github.com/user-attachments/assets/206c29d0-9e0b-47a1-9998-5654698b50e9" />

after:
<img width="1369" height="859" alt="image" src="https://github.com/user-attachments/assets/f5a9036b-62fa-4ef1-8280-fbdd0ed75961" />

## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
