### PR TITLE
Fix login error message [OP-2566]

### DIFF
--- a/core/services/userServices.py
+++ b/core/services/userServices.py
@@ -295,6 +295,9 @@ def user_authentication(request, username, password):
         else:
             logger.debug(f"Authentication failed for username: {username}")
             raise exceptions.AuthenticationFailed("INCORRECT_CREDENTIALS")
+    if not user:
+        logger.debug(f"Authentication failed for username: {username}")
+        raise exceptions.AuthenticationFailed("INCORRECT_CREDENTIALS")
     return user
 
 

--- a/core/services/userServices.py
+++ b/core/services/userServices.py
@@ -274,31 +274,38 @@ def set_user_password(request, username, token, password):
         raise ValidationError("Invalid Token")
 
 
+def _clear_jwt_cookies(request):
+    if hasattr(request, "COOKIES") and isinstance(request.COOKIES, dict):
+        request.COOKIES.pop("JWT", None)
+        request.COOKIES.pop("JWT-refresh-token", None)
+
+
+def _try_auto_provision(username, password):
+    user, provisioned = UserManager().auto_provision_user(username=username)
+    if provisioned:
+        logger.debug(f"User {username} was automatically provisioned")
+    if user and user.i_user.check_password(password):
+        return user
+    return None
+
+
 def user_authentication(request, username, password):
-    user = None
     if not username or not password:
         raise exceptions.ParseError(_("Missing username or password"))
-    try:
-        if hasattr(request, "COOKIES") and isinstance(request.COOKIES, dict):
-            request.COOKIES.pop("JWT", None)
-            request.COOKIES.pop("JWT-refresh-token", None)
-        user = authenticate(request, username=username, password=password)
-    except Exception as exc:
-        logger.debug(f"Authentication failed for username: {username}:{exc}")
 
-    if not user and not User.objects.filter(username__iexact=username).exists():
-        user, provisioned = UserManager().auto_provision_user(username=username)
-        if provisioned:
-            logger.debug(f"user {username} was automatically provisioned")
-        if user and user.i_user.check_password(password):
+    _clear_jwt_cookies(request)
+
+    user = authenticate(request, username=username, password=password)
+    if user:
+        return user
+
+    if not User.objects.filter(username__iexact=username).exists():
+        user = _try_auto_provision(username, password)
+        if user:
             return user
-        else:
-            logger.debug(f"Authentication failed for username: {username}")
-            raise exceptions.AuthenticationFailed("INCORRECT_CREDENTIALS")
-    if not user:
-        logger.debug(f"Authentication failed for username: {username}")
-        raise exceptions.AuthenticationFailed("INCORRECT_CREDENTIALS")
-    return user
+
+    logger.debug(f"Authentication failed for username: {username}")
+    raise exceptions.AuthenticationFailed("INCORRECT_CREDENTIALS")
 
 
 def check_user_unique_email(user_email):

--- a/core/tests/test_graphql.py
+++ b/core/tests/test_graphql.py
@@ -78,6 +78,33 @@ class gqlTest(openIMISGraphQLTestCase):
         self.assertResponseHasErrors(response)
         _ = json.loads(response.content)
 
+    def test_login_wrong_credentials_prevents_user_enumeration(self):
+        """Both wrong password and non-existent user should return identical error responses."""
+        query = """
+            mutation authenticate($username: String!, $password: String!) {
+                tokenAuth(username: $username, password: $password)
+                {
+                refreshExpiresIn
+                }
+            }
+        """
+        wrong_password_response = self.query(
+            query, variables={"username": str(self.admin_username), "password": "wrongpass"}
+        )
+        nonexistent_user_response = self.query(
+            query, variables={"username": "nonexistent_user_xyz", "password": "anypass"}
+        )
+
+        wrong_password_data = json.loads(wrong_password_response.content)
+        nonexistent_user_data = json.loads(nonexistent_user_response.content)
+
+        self.assertEqual(wrong_password_response.status_code, nonexistent_user_response.status_code)
+        self.assertEqual(
+            wrong_password_data["errors"][0]["message"],
+            nonexistent_user_data["errors"][0]["message"]
+        )
+        self.assertEqual(wrong_password_data["errors"][0]["message"], "INCORRECT_CREDENTIALS")
+
     def test_change_langue(self):
         query = """
             mutation {

--- a/core/tests/test_services.py
+++ b/core/tests/test_services.py
@@ -4,8 +4,11 @@ import datetime
 
 from django.test.client import RequestFactory
 from django.apps import apps
+from django.test import TestCase
+from rest_framework.exceptions import AuthenticationFailed, ParseError
+
 import core
-from core.models import Language
+from core.models import InteractiveUser, Language, User
 from core.services import (
     create_or_update_interactive_user,
     create_or_update_core_user,
@@ -13,14 +16,14 @@ from core.services import (
     create_or_update_claim_admin,
     reset_user_password,
     set_user_password,
+    user_authentication,
 )
-from django.test import TestCase
-from location.models import OfficerVillage
-from location.test_helpers import create_test_village, create_test_health_facility
 from core.test_helpers import (
     create_test_interactive_user,
     create_test_role,
 )
+from location.models import OfficerVillage
+from location.test_helpers import create_test_village, create_test_health_facility
 logger = logging.getLogger(__file__)
 PASSWORD = "FoBoar72!"
 
@@ -491,3 +494,56 @@ class UserServicesTest(TestCase):
         request = self.factory.get("/")
         with self.assertRaises(ValidationError):
             set_user_password(request, username, "TOKEN", "new_password")
+
+
+class UserAuthenticationTest(TestCase):
+    legacy_username = "legacy_user_test"
+    legacy_password = "Legacy123!"
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        language, _ = Language.objects.get_or_create(
+            code="en", defaults={"name": "English", "sort_order": 1}
+        )
+        self.legacy_i_user = InteractiveUser.objects.create(
+            login_name=self.legacy_username,
+            other_names="Legacy",
+            last_name="User",
+            language=language,
+        )
+        self.legacy_i_user.set_password(self.legacy_password)
+        self.legacy_i_user.save()
+
+    def test_missing_username_raises_parse_error(self):
+        request = self.factory.post("/")
+        with self.assertRaises(ParseError):
+            user_authentication(request, None, "password")
+
+        with self.assertRaises(ParseError):
+            user_authentication(request, "", "password")
+
+    def test_missing_password_raises_parse_error(self):
+        request = self.factory.post("/")
+        with self.assertRaises(ParseError):
+            user_authentication(request, "username", None)
+
+        with self.assertRaises(ParseError):
+            user_authentication(request, "username", "")
+
+    def test_auto_provision_creates_user_for_legacy_interactive_user(self):
+        self.assertFalse(User.objects.filter(username=self.legacy_username).exists())
+
+        request = self.factory.post("/")
+        user = user_authentication(request, self.legacy_username, self.legacy_password)
+
+        self.assertIsNotNone(user)
+        self.assertTrue(User.objects.filter(username=self.legacy_username).exists())
+        self.assertEqual(user.i_user.id, self.legacy_i_user.id)
+
+    def test_auto_provision_fails_with_wrong_password(self):
+        self.assertFalse(User.objects.filter(username=self.legacy_username).exists())
+
+        request = self.factory.post("/")
+        with self.assertRaises(AuthenticationFailed):
+            user_authentication(request, self.legacy_username, "wrong_password")


### PR DESCRIPTION
# Description

When an incorrect password is entered, the error message shows `cannot read properties of undefined (reading "tokenAuth")`. This PR fixes it and now it shows `The password or the username you've entered is incorrect.`

This fixes a current security vulnerability where an attacker could probe usernames as an existent vs. non-existent usernames return different HTTP response codes – see regression test added `test_login_wrong_credentials_prevents_user_enumeration`.

Additional unit tests to cover logic branches of `user_authentication`. Also refactored `user_authentication` for better readability and flow.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira): https://openimis.atlassian.net/browse/OP-2566

## Demo

<img width="1086" height="816" alt="image" src="https://github.com/user-attachments/assets/0facef4d-161a-4431-9d2d-42f5fb937bf1" />

## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
