### PR TITLE
fix: widen tblOfficer Code and VEOCode columns to varchar(50)

### DIFF
--- a/core/migrations/0036_widen_officer_code_columns.py
+++ b/core/migrations/0036_widen_officer_code_columns.py
@@ -1,5 +1,119 @@
-from django.conf import settings
-from django.db import migrations
+from django.db import connection, migrations
+
+
+PG_COLUMNS = [("Code", "varchar(50)"), ("VEOCode", "varchar(50)")]
+MSSQL_COLUMNS = [("Code", "NVARCHAR(50) NOT NULL"), ("VEOCode", "NVARCHAR(50) NULL")]
+
+
+def widen_officer_code_columns(apps, schema_editor):
+    if connection.vendor == "postgresql":
+        _widen_postgresql()
+    elif connection.vendor == "microsoft":
+        _widen_mssql()
+
+
+def _pg_column_length(cursor, column_name):
+    cursor.execute(
+        "SELECT character_maximum_length FROM information_schema.columns "
+        "WHERE table_schema = current_schema() AND table_name = 'tblOfficer' "
+        "AND column_name = %s",
+        [column_name],
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+def _pg_dependent_views(cursor, column_names):
+    cursor.execute(
+        """
+        SELECT DISTINCT ns.nspname, v.relname
+        FROM pg_depend d
+        JOIN pg_rewrite r ON r.oid = d.objid
+        JOIN pg_class v ON v.oid = r.ev_class AND v.relkind = 'v'
+        JOIN pg_namespace ns ON ns.oid = v.relnamespace
+        JOIN pg_class t ON t.oid = d.refobjid
+        JOIN pg_attribute a
+          ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+        WHERE t.relname = 'tblOfficer' AND a.attname = ANY(%s)
+        """,
+        [list(column_names)],
+    )
+    return [(schema, name) for schema, name in cursor.fetchall()]
+
+
+def _widen_postgresql():
+    with connection.cursor() as cursor:
+        to_widen = [
+            (col, new_type)
+            for col, new_type in PG_COLUMNS
+            if (_pg_column_length(cursor, col) or 0) < 50
+        ]
+        if not to_widen:
+            return
+
+        col_names = [col for col, _ in to_widen]
+        dependent_views = _pg_dependent_views(cursor, col_names)
+
+        view_defs = []
+        for schema, name in dependent_views:
+            cursor.execute(
+                "SELECT definition FROM pg_views "
+                "WHERE schemaname = %s AND viewname = %s",
+                [schema, name],
+            )
+            row = cursor.fetchone()
+            if row:
+                view_defs.append((schema, name, row[0]))
+
+        for schema, name, _ in view_defs:
+            cursor.execute(f'DROP VIEW IF EXISTS "{schema}"."{name}" CASCADE')
+
+        for col, new_type in to_widen:
+            cursor.execute(
+                f'ALTER TABLE "tblOfficer" ALTER COLUMN "{col}" TYPE {new_type}'
+            )
+
+        _recreate_postgresql_views(cursor, view_defs)
+
+
+def _recreate_postgresql_views(cursor, view_defs):
+    pending = [
+        (schema, name, f'CREATE OR REPLACE VIEW "{schema}"."{name}" AS {definition}')
+        for schema, name, definition in view_defs
+    ]
+    while pending:
+        progress = False
+        remaining = []
+        for schema, name, ddl in pending:
+            cursor.execute("SAVEPOINT recreate_view")
+            try:
+                cursor.execute(ddl)
+                cursor.execute("RELEASE SAVEPOINT recreate_view")
+                progress = True
+            except Exception:
+                cursor.execute("ROLLBACK TO SAVEPOINT recreate_view")
+                cursor.execute("RELEASE SAVEPOINT recreate_view")
+                remaining.append((schema, name, ddl))
+        if not progress:
+            cursor.execute(remaining[0][2])
+        pending = remaining
+
+
+def _widen_mssql():
+    with connection.cursor() as cursor:
+        for col, new_type in MSSQL_COLUMNS:
+            cursor.execute(
+                "SELECT CHARACTER_MAXIMUM_LENGTH FROM INFORMATION_SCHEMA.COLUMNS "
+                "WHERE TABLE_NAME = 'tblOfficer' AND COLUMN_NAME = %s",
+                [col],
+            )
+            row = cursor.fetchone()
+            current = row[0] if row else None
+            if current is None or current >= 50:
+                continue
+            cursor.execute(
+                f"ALTER TABLE [tblOfficer] ALTER COLUMN [{col}] {new_type};"
+            )
 
 
 class Migration(migrations.Migration):
@@ -8,30 +122,22 @@ class Migration(migrations.Migration):
     varchar(8) (their original 0008 definition) to varchar(50).
 
     Migration 0020 already declares an AlterField for these columns, but on
-    environments initialised from a legacy SQL dump with the historical
-    migrations faked, the underlying ALTER COLUMN never executed. Saving an
-    officer whose username is longer than 8 characters (e.g. via the frontend
-    /admin/users screen when adding a role) then fails with
-    "value too long for type character varying(8)". Running this SQL directly
-    is a no-op when the columns are already varchar(50).
+    environments initialised from a legacy SQL dump with historical migrations
+    faked, the underlying ALTER COLUMN never executed. Saving an officer whose
+    username is longer than 8 characters (e.g. via /admin/users when adding a
+    role) then fails with "value too long for type character varying(8)".
+
+    The operation is a no-op when the columns are already at least 50
+    characters wide, so it is safe to run on freshly-migrated databases.
     """
 
     dependencies = [
         ("core", "0035_migrate_admin_users_to_superuser"),
     ]
 
-    psql_forward = (
-        'ALTER TABLE "tblOfficer" ALTER COLUMN "Code" TYPE varchar(50);'
-        'ALTER TABLE "tblOfficer" ALTER COLUMN "VEOCode" TYPE varchar(50);'
-    )
-    mssql_forward = (
-        "ALTER TABLE [tblOfficer] ALTER COLUMN [Code] NVARCHAR(50) NOT NULL;"
-        "ALTER TABLE [tblOfficer] ALTER COLUMN [VEOCode] NVARCHAR(50) NULL;"
-    )
-
     operations = [
-        migrations.RunSQL(
-            mssql_forward if settings.MSSQL else psql_forward,
-            reverse_sql=migrations.RunSQL.noop,
+        migrations.RunPython(
+            widen_officer_code_columns,
+            reverse_code=migrations.RunPython.noop,
         ),
     ]

--- a/core/migrations/0036_widen_officer_code_columns.py
+++ b/core/migrations/0036_widen_officer_code_columns.py
@@ -1,0 +1,37 @@
+from django.conf import settings
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """
+    Re-apply the widening of tblOfficer.Code and tblOfficer.VEOCode from
+    varchar(8) (their original 0008 definition) to varchar(50).
+
+    Migration 0020 already declares an AlterField for these columns, but on
+    environments initialised from a legacy SQL dump with the historical
+    migrations faked, the underlying ALTER COLUMN never executed. Saving an
+    officer whose username is longer than 8 characters (e.g. via the frontend
+    /admin/users screen when adding a role) then fails with
+    "value too long for type character varying(8)". Running this SQL directly
+    is a no-op when the columns are already varchar(50).
+    """
+
+    dependencies = [
+        ("core", "0035_migrate_admin_users_to_superuser"),
+    ]
+
+    psql_forward = (
+        'ALTER TABLE "tblOfficer" ALTER COLUMN "Code" TYPE varchar(50);'
+        'ALTER TABLE "tblOfficer" ALTER COLUMN "VEOCode" TYPE varchar(50);'
+    )
+    mssql_forward = (
+        "ALTER TABLE [tblOfficer] ALTER COLUMN [Code] NVARCHAR(50) NOT NULL;"
+        "ALTER TABLE [tblOfficer] ALTER COLUMN [VEOCode] NVARCHAR(50) NULL;"
+    )
+
+    operations = [
+        migrations.RunSQL(
+            mssql_forward if settings.MSSQL else psql_forward,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]


### PR DESCRIPTION
## Summary

Fixes `value too long for type character varying(8)` when saving an officer user from `/admin/users` (e.g. when adding a new role) whose username is longer than 8 characters.

https://openimis.atlassian.net/browse/OP-3000 

## Root cause

- Migration [0008_officer_role_roleright_userrole.py](../blob/release/26.04/core/migrations/0008_officer_role_roleright_userrole.py) created `tblOfficer.Code` as `varchar(8)`.
- Migration [0020_add_missing_fields_to_django_scheme.py](../blob/release/26.04/core/migrations/0020_add_missing_fields_to_django_scheme.py) declares an `AlterField` widening it to `varchar(50)` (matching the current model definition).
- On environments initialised from a legacy SQL dump with historical migrations faked, the `ALTER COLUMN` from 0020 never actually executed. `tblOfficer.Code` stays at `varchar(8)` while the Django model assumes `varchar(50)`.
- `core.services.userServices.create_or_update_officer` unconditionally writes `username` into `Officer.code` on every save of an officer user, so adding a role to an officer with a >8-char username triggers the DB error.

## Change

Adds `0036_widen_officer_code_columns.py`, a `RunPython` migration that:

- Reads `character_maximum_length` for `tblOfficer.Code` / `VEOCode` from `information_schema` and no-ops when both columns are already at least 50 characters wide. This makes the migration safe to run on freshly-migrated databases where 0020 applied cleanly.
- On PostgreSQL, when the columns are narrow, discovers dependent views from `pg_depend` (e.g. `uvwNumberInsureeAcquired`), drops them with `CASCADE`, widens the columns, and recreates the views. Recreation uses a savepoint-based retry loop so inter-view dependencies resolve without a hard-coded order.
- On MSSQL, gates the `ALTER COLUMN` on the same length check and applies it only where needed.
- `reverse_code` is a no-op to avoid narrowing the columns on rollback.

## Test plan

- [ ] Apply the migration on a database where `tblOfficer.Code` is `varchar(8)` and confirm it becomes `varchar(50)` without data loss.
- [ ] On a freshly-migrated database (where 0020 applied cleanly), confirm the migration runs without error and is a no-op on the column types.
- [ ] From the frontend `/admin/users` screen, edit an officer user whose username is 9–12 characters, add a role, save — confirm the save succeeds.
- [ ] Repeat the edit flow against both PostgreSQL and MSSQL backends.

## CI note

`Default CI Flow / Run All Tests (PSQL)` is red on this PR, but the failures are pre-existing on `release/26.04` and unrelated to this migration.

Comparison against the last merge run on `release/26.04` (commit `bc7b50e`):

| | Baseline (`release/26.04` @ `bc7b50e`) | PR #421 |
|---|---|---|
| Tests | 472 | 532 |
| Errors | 160 | 192 |

No previously-passing test regressed. The 32 extra errors all come from two newly-introduced modules (`calcrule_timesheet` and `grievance_social_protection`) and are `setUpClass` failures for reasons unrelated to officer/user code paths or `tblOfficer` (image-file handling, missing HF pricelist setup, cascading `connection already closed` after the first fatal, etc.). No `Applying core.0036` / `cannot alter type` / `tblOfficer` errors appear in the log — the new migration is silent in the fresh test DB, which is the intended behavior.

The `Run Module Tests (PSQL)` job, which runs this repository's own test suite, passes.