### PR TITLE
fix(schema): accept Date instead of DateTime for worksTo in UserBase input

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -1709,7 +1709,7 @@ class UserBase:
     # Enrolment Officer / Feedback / Claim Admin specific
     birth_date = graphene.Date(required=False)
     address = graphene.String(required=False)  # multi-line
-    works_to = graphene.DateTime(required=False)
+    works_to = graphene.Date(required=False)
     substitution_officer_id = graphene.Int(required=False)
     # TODO VEO_code, last_name, other names, dob, phone
     phone_communication = graphene.Boolean(required=False)


### PR DESCRIPTION
## Summary

- User creation/update fails silently when the **Works To** date field is populated in Administration → Users
- The UI date picker sends `"YYYY-MM-DD"` (a Date string), but the GraphQL input type for `worksTo` was declared as `graphene.DateTime`
- Graphene rejects the value before the service layer is ever reached, with:
  ```
  In field "worksTo": Expected type "DateTime", found "2026-02-03".
  ```
- Fix: change `works_to = graphene.DateTime(required=False)` → `works_to = graphene.Date(required=False)` in `UserBase`, matching the existing `birth_date = graphene.Date(...)` pattern

## Why this is the right fix (backend, not frontend)

The UI only ever collects a calendar date — there is no time or timezone involved in "works until" semantics. Changing the GraphQL type to `Date` is the semantically correct choice, consistent with `birth_date` which has always been `graphene.Date`.

No service layer change is needed: Django's `DateTimeField.to_python()` already coerces a plain `date` object to midnight `datetime`, which the existing tests confirm (`works_to=datetime.date(2025, 5, 5)` → asserted via `officer.works_to.date()`).

No database migration is required: the underlying `Officer.works_to` column remains `DateTimeField` / `DateTimeField` — only the GraphQL input type changes.

## Test plan

- [ ] Create an Enrolment Officer user with **Works To** populated — mutation should succeed
- [ ] Update an existing officer user, change **Works To** — should succeed
- [ ] Leave **Works To** blank — should still succeed (field is `required=False`)
- [ ] Existing `test_services.py` officer tests pass (they already use `date` objects for `works_to`)