### PR TITLE
fix: enforce strict username uniqueness in validateUsername (backport to release/25.10)

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -957,9 +957,7 @@ class Query(graphene.ObjectType):
     def resolve_validate_username(self, info, **kwargs):
         if not info.context.user.has_perms(CoreConfig.gql_query_users_perms):
             raise PermissionDenied(_("unauthorized"))
-        if User.objects.filter(
-            username=kwargs["username"], validity_to__isnull=True
-        ).exists():
+        if User.objects.filter(username=kwargs["username"]).exists():
             return False
         else:
             return True

--- a/core/tests/test_graphql.py
+++ b/core/tests/test_graphql.py
@@ -221,3 +221,29 @@ class gqlTest(openIMISGraphQLTestCase):
             query, headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"}
         )
         self.assertResponseNoErrors(response)
+
+    def test_validate_username_existing(self):
+        # Test validateUsername with an existing username - should return False
+        query = """
+            query ($username: String!) {
+                isValid: validateUsername(username: $username)
+            }
+        """
+        variables = {"username": self.admin_username}
+        response = self.query(query, variables=variables, headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"})
+        self.assertResponseNoErrors(response)
+        content = json.loads(response.content)
+        self.assertFalse(content["data"]["isValid"])
+
+    def test_validate_username_non_existing(self):
+        # Test validateUsername with a non-existing username - should return True
+        query = """
+            query ($username: String!) {
+                isValid: validateUsername(username: $username)
+            }
+        """
+        variables = {"username": "nonexistingusername123"}
+        response = self.query(query, variables=variables, headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"})
+        self.assertResponseNoErrors(response)
+        content = json.loads(response.content)
+        self.assertTrue(content["data"]["isValid"])


### PR DESCRIPTION
## Summary

Backport of [PR #415](https://github.com/openimis/openimis-be-core_py/pull/415) (commit `9d02ae9`) to `release/25.10`.

The fix is already in `develop` and `release/26.04` but was never backported to `release/25.10`.

## Bug

`resolve_validate_username` (used by the frontend to show real-time username availability feedback) filtered with `validity_to__isnull=True`:

```python
# release/25.10 — buggy
if User.objects.filter(
    username=kwargs["username"], validity_to__isnull=True
).exists():
    return False
```

`User` records carry a `validity_to` field (from `OpenIMISHistoryMixin`). If a user record ever has `validity_to` set (soft-deleted), this filter skips it and `validateUsername` incorrectly returns `True` (available) — inconsistent with the DB-level `UNIQUE` constraint, which always enforces uniqueness regardless of validity. The frontend would report the username as free but the actual mutation would fail.

## Fix

Remove the `validity_to__isnull=True` predicate so uniqueness is checked against **all** User records, matching the DB constraint:

```python
# fixed
if User.objects.filter(username=kwargs["username"]).exists():
    return False
```

Two regression tests added: one for an existing username (must return `False`) and one for a non-existing username (must return `True`).

## Conflict resolution

The cherry-pick conflicted in `test_graphql.py` because `develop` had additional tests not yet in `release/25.10`. Only the two `validateUsername` tests were backported; the unrelated `test_user_modification_creates_history_with_user` test was excluded as it belongs to a separate feature.