### PR TITLE
feat: add to_date and subtract_date_ranges utilities to core

### DIFF
--- a/core/datetimes/shared.py
+++ b/core/datetimes/shared.py
@@ -1,6 +1,6 @@
 from datetime import timedelta, date, datetime
 
-__all__ = ["is_midnight", "datetimedelta"]
+__all__ = ["is_midnight", "datetimedelta", "to_date"]
 
 
 def _cmperror(x, y):
@@ -17,6 +17,19 @@ def is_midnight(dt):
     if hasattr(dt, "microsecond") and dt.microsecond != 0:
         return False
     return True
+
+
+def to_date(d):
+    """Normalize any date-like value to a plain date, stripping any time component.
+
+    AdDate.to_ad_date() returns self; AdDatetime.to_ad_date() returns AdDate.
+    Plain datetime.datetime has .date(); plain datetime.date does not.
+    """
+    if hasattr(d, "to_ad_date"):
+        return d.to_ad_date()
+    if hasattr(d, "date") and callable(d.date):
+        return d.date()
+    return d
 
 
 def _cmp(x, y):

--- a/core/utils.py
+++ b/core/utils.py
@@ -50,6 +50,7 @@ __all__ = [
     "ExtendedConnection",
     "get_scheduler_method_ref",
     "ExtendedRelayConnection",
+    "subtract_date_ranges",
 ]
 
 
@@ -1078,4 +1079,31 @@ def migrate_from_versioned_to_history(model_class, history_model_class):
 
     result = f"Migrated {migrated_count} records to history for {model_class.__name__}"
     logger.info(result)
+    return result
+
+
+def subtract_date_ranges(main_range, date_ranges):
+    from core import to_date
+
+    main_start = to_date(main_range[0])
+    main_end = to_date(main_range[1])
+    result = []
+    current = main_start
+
+    sorted_ranges = sorted(date_ranges, key=lambda x: to_date(x[0]))
+
+    for start, end in sorted_ranges:
+        start = to_date(start)
+        end = to_date(end)
+        if current < start:
+            result.append((current, min(start, main_end)))
+
+        current = max(current, end)
+
+        if current >= main_end:
+            break
+
+    if current < main_end:
+        result.append((current, main_end))
+
     return result


### PR DESCRIPTION
## Summary

- Adds `to_date(d)` to `core/datetimes/shared.py` — normalizes any `AdDatetime`, `datetime.datetime`, `AdDate`, or `datetime.date` value to a plain date by stripping any time component. Exported via `__all__` so it is available as `from core import to_date`.
- Adds `subtract_date_ranges(main_range, date_ranges)` to `core/utils.py` — computes the uncovered sub-ranges within a main date range after subtracting a list of covered ranges. Exported via `__all__` so it is available as `from core import subtract_date_ranges`.

## Context

These utilities were previously defined locally in `openimis-be-contract_py`. Reviewer @delcroip noted in [openimis-be-contract_py#114](https://github.com/openimis/openimis-be-contract_py/pull/114) that the logic should be managed at core level since it deals with core date types (`AdDate`/`AdDatetime`) and is generically reusable.

A companion PR on `openimis-be-contract_py` removes the local definitions and imports both utilities from core.
