### PR TITLE
Feature: manage module config validation & reload

### DIFF
--- a/core/models/base.py
+++ b/core/models/base.py
@@ -97,7 +97,7 @@ class ModuleConfiguration(UUIDModel):
         validate_module_configuration(self)
 
     def save(self, *args, **kwargs):
-        self.full_clean()
+        self.clean()
         super().save(*args, **kwargs)
         reload_module_configuration(self)
 

--- a/core/models/base.py
+++ b/core/models/base.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime as py_datetime
 import datetime as base_datetime
 from cached_property import cached_property
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q, JSONField
 
@@ -94,6 +95,13 @@ class ModuleConfiguration(UUIDModel):
         return json.loads(self.config, object_pairs_hook=collections.OrderedDict)
 
     def clean(self):
+        super().clean()
+
+        try:
+            self._cfg
+        except (TypeError, json.JSONDecodeError) as e:
+            raise ValidationError({"config": f"Invalid JSON: {e}"})
+
         validate_module_configuration(self)
 
     def save(self, *args, **kwargs):

--- a/core/models/base.py
+++ b/core/models/base.py
@@ -10,6 +10,8 @@ from cached_property import cached_property
 from django.db import models
 from django.db.models import Q, JSONField
 
+from core.module_config_registry import validate_module_configuration, reload_module_configuration
+
 # from core.datetimes.ad_datetime import datetime as py_datetime
 
 
@@ -90,6 +92,14 @@ class ModuleConfiguration(UUIDModel):
         import collections
 
         return json.loads(self.config, object_pairs_hook=collections.OrderedDict)
+
+    def clean(self):
+        validate_module_configuration(self)
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super().save(*args, **kwargs)
+        reload_module_configuration(self)
 
     def __str__(self):
         return "%s [%s]" % (self.module, self.version)

--- a/core/models/base.py
+++ b/core/models/base.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import logging
@@ -62,11 +63,12 @@ class ModuleConfiguration(UUIDModel):
 
     @classmethod
     def get_or_default(cls, module, default, layer="be"):
+        defaults = copy.deepcopy(default)
         if bool(os.environ.get("NO_DATABASE", False)):
             logger.info(
                 "env NO_DATABASE set to True: ModuleConfiguration not loaded from db!"
             )
-            return default
+            return defaults
 
         try:
             now = py_datetime.now()  # can't use core config here...
@@ -77,16 +79,16 @@ class ModuleConfiguration(UUIDModel):
             ).first()
             if qs:
                 db_configuration = qs._cfg
-                return {**default, **db_configuration}
+                return {**defaults, **db_configuration}
             else:
                 logger.info("No %s configuration, using default!" % module)
-                return default
+                return defaults
         except Exception:
             logger.error(
                 "Failed to load %s configuration, using default!\n%s: %s"
                 % (module, sys.exc_info()[0].__name__, sys.exc_info()[1])
             )
-            return default
+            return defaults
 
     @cached_property
     def _cfg(self):

--- a/core/models/base.py
+++ b/core/models/base.py
@@ -8,7 +8,7 @@ from datetime import datetime as py_datetime
 import datetime as base_datetime
 from cached_property import cached_property
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q, JSONField
 
 from core.module_config_registry import validate_module_configuration, reload_module_configuration
@@ -107,7 +107,7 @@ class ModuleConfiguration(UUIDModel):
     def save(self, *args, **kwargs):
         self.clean()
         super().save(*args, **kwargs)
-        reload_module_configuration(self)
+        transaction.on_commit(lambda: reload_module_configuration(self))
 
     def __str__(self):
         return "%s [%s]" % (self.module, self.version)

--- a/core/module_config_registry.py
+++ b/core/module_config_registry.py
@@ -1,0 +1,28 @@
+_validators = {}
+_reloaders = {}
+
+
+def _key(module, layer="be"):
+    return (module, layer)
+
+
+def register_validator(module, fn, layer="be"):
+    key = _key(module, layer)
+    if fn not in _validators.setdefault(key, []):
+        _validators[key].append(fn)
+
+
+def register_reloader(module, fn, layer="be"):
+    key = _key(module, layer)
+    if fn not in _reloaders.setdefault(key, []):
+        _reloaders[key].append(fn)
+
+
+def validate_module_configuration(instance):
+    for fn in _validators.get(_key(instance.module, instance.layer), []):
+        fn(instance)
+
+
+def reload_module_configuration(instance):
+    for fn in _reloaders.get(_key(instance.module, instance.layer), []):
+        fn(instance)

--- a/core/tests/test_module_config_registry.py
+++ b/core/tests/test_module_config_registry.py
@@ -13,6 +13,14 @@ from core.module_config_registry import (
 )
 
 
+def _noop(instance):
+    pass
+
+
+def _noop_alt(instance):
+    pass
+
+
 class ModuleConfigRegistryTest(TestCase):
 
     def setUp(self):
@@ -26,29 +34,24 @@ class ModuleConfigRegistryTest(TestCase):
         _reloaders.update(self._saved_reloaders)
 
     def test_register_validator(self):
-        def noop(instance): pass
-        register_validator("test_module", noop)
-        self.assertIn(noop, _validators[_key("test_module")])
+        register_validator("test_module", _noop)
+        self.assertIn(_noop, _validators[_key("test_module")])
 
     def test_register_reloader(self):
-        def noop(instance): pass
-        register_reloader("test_module", noop)
-        self.assertIn(noop, _reloaders[_key("test_module")])
+        register_reloader("test_module", _noop)
+        self.assertIn(_noop, _reloaders[_key("test_module")])
 
     def test_no_duplicate_registration(self):
-        def noop(instance): pass
-        register_validator("test_module", noop)
-        register_validator("test_module", noop)
-        self.assertEqual(_validators[_key("test_module")].count(noop), 1)
+        register_validator("test_module", _noop)
+        register_validator("test_module", _noop)
+        self.assertEqual(_validators[_key("test_module")].count(_noop), 1)
 
     def test_layer_isolation(self):
-        def noop_be(instance): pass
-        def noop_fe(instance): pass
-        register_validator("test_module", noop_be, layer="be")
-        register_validator("test_module", noop_fe, layer="fe")
-        self.assertIn(noop_be, _validators[_key("test_module", "be")])
-        self.assertIn(noop_fe, _validators[_key("test_module", "fe")])
-        self.assertNotIn(noop_fe, _validators[_key("test_module", "be")])
+        register_validator("test_module", _noop, layer="be")
+        register_validator("test_module", _noop_alt, layer="fe")
+        self.assertIn(_noop, _validators[_key("test_module", "be")])
+        self.assertIn(_noop_alt, _validators[_key("test_module", "fe")])
+        self.assertNotIn(_noop_alt, _validators[_key("test_module", "be")])
 
     def test_validate_calls_matching_validators(self):
         calls = []

--- a/core/tests/test_module_config_registry.py
+++ b/core/tests/test_module_config_registry.py
@@ -1,0 +1,82 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from core.forms import ModuleConfigurationForm
+from core.models import ModuleConfiguration
+from core.module_config_registry import (
+    _validators,
+    _reloaders,
+    _key,
+    register_validator,
+    register_reloader,
+    validate_module_configuration,
+    reload_module_configuration,
+)
+
+
+class ModuleConfigRegistryTest(TestCase):
+
+    def setUp(self):
+        self._saved_validators = dict(_validators)
+        self._saved_reloaders = dict(_reloaders)
+
+    def tearDown(self):
+        _validators.clear()
+        _validators.update(self._saved_validators)
+        _reloaders.clear()
+        _reloaders.update(self._saved_reloaders)
+
+    def test_register_validator(self):
+        fn = lambda instance: None
+        register_validator("test_module", fn)
+        self.assertIn(fn, _validators[_key("test_module")])
+
+    def test_register_reloader(self):
+        fn = lambda instance: None
+        register_reloader("test_module", fn)
+        self.assertIn(fn, _reloaders[_key("test_module")])
+
+    def test_no_duplicate_registration(self):
+        fn = lambda instance: None
+        register_validator("test_module", fn)
+        register_validator("test_module", fn)
+        self.assertEqual(_validators[_key("test_module")].count(fn), 1)
+
+    def test_layer_isolation(self):
+        fn_be = lambda instance: None
+        fn_fe = lambda instance: None
+        register_validator("test_module", fn_be, layer="be")
+        register_validator("test_module", fn_fe, layer="fe")
+        self.assertIn(fn_be, _validators[_key("test_module", "be")])
+        self.assertIn(fn_fe, _validators[_key("test_module", "fe")])
+        self.assertNotIn(fn_fe, _validators[_key("test_module", "be")])
+
+    def test_validate_calls_matching_validators(self):
+        calls = []
+        register_validator("mod_a", lambda inst: calls.append("a"))
+        register_validator("mod_b", lambda inst: calls.append("b"))
+
+        instance = ModuleConfiguration(module="mod_a", layer="be", version="1", config="{}")
+        validate_module_configuration(instance)
+        self.assertEqual(calls, ["a"])
+
+    def test_reload_calls_matching_reloaders(self):
+        calls = []
+        register_reloader("mod_a", lambda inst: calls.append("a"))
+        register_reloader("mod_b", lambda inst: calls.append("b"))
+
+        instance = ModuleConfiguration(module="mod_a", layer="be", version="1", config="{}")
+        reload_module_configuration(instance)
+        self.assertEqual(calls, ["a"])
+
+    def test_validate_propagates_validation_error(self):
+        register_validator("mod_x", lambda inst: (_ for _ in ()).throw(ValidationError("bad config")))
+        instance = ModuleConfiguration(module="mod_x", layer="be", version="1", config="{}")
+
+        with self.assertRaises(ValidationError):
+            validate_module_configuration(instance)
+
+    def test_no_validators_for_module_is_noop(self):
+        instance = ModuleConfiguration(module="unregistered", layer="be", version="1", config="{}")
+        validate_module_configuration(instance)
+        reload_module_configuration(instance)

--- a/core/tests/test_module_config_registry.py
+++ b/core/tests/test_module_config_registry.py
@@ -26,29 +26,29 @@ class ModuleConfigRegistryTest(TestCase):
         _reloaders.update(self._saved_reloaders)
 
     def test_register_validator(self):
-        fn = lambda instance: None
-        register_validator("test_module", fn)
-        self.assertIn(fn, _validators[_key("test_module")])
+        def noop(instance): pass
+        register_validator("test_module", noop)
+        self.assertIn(noop, _validators[_key("test_module")])
 
     def test_register_reloader(self):
-        fn = lambda instance: None
-        register_reloader("test_module", fn)
-        self.assertIn(fn, _reloaders[_key("test_module")])
+        def noop(instance): pass
+        register_reloader("test_module", noop)
+        self.assertIn(noop, _reloaders[_key("test_module")])
 
     def test_no_duplicate_registration(self):
-        fn = lambda instance: None
-        register_validator("test_module", fn)
-        register_validator("test_module", fn)
-        self.assertEqual(_validators[_key("test_module")].count(fn), 1)
+        def noop(instance): pass
+        register_validator("test_module", noop)
+        register_validator("test_module", noop)
+        self.assertEqual(_validators[_key("test_module")].count(noop), 1)
 
     def test_layer_isolation(self):
-        fn_be = lambda instance: None
-        fn_fe = lambda instance: None
-        register_validator("test_module", fn_be, layer="be")
-        register_validator("test_module", fn_fe, layer="fe")
-        self.assertIn(fn_be, _validators[_key("test_module", "be")])
-        self.assertIn(fn_fe, _validators[_key("test_module", "fe")])
-        self.assertNotIn(fn_fe, _validators[_key("test_module", "be")])
+        def noop_be(instance): pass
+        def noop_fe(instance): pass
+        register_validator("test_module", noop_be, layer="be")
+        register_validator("test_module", noop_fe, layer="fe")
+        self.assertIn(noop_be, _validators[_key("test_module", "be")])
+        self.assertIn(noop_fe, _validators[_key("test_module", "fe")])
+        self.assertNotIn(noop_fe, _validators[_key("test_module", "be")])
 
     def test_validate_calls_matching_validators(self):
         calls = []

--- a/core/tests/test_module_config_registry.py
+++ b/core/tests/test_module_config_registry.py
@@ -1,7 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from core.forms import ModuleConfigurationForm
 from core.models import ModuleConfiguration
 from core.module_config_registry import (
     _validators,
@@ -70,7 +69,10 @@ class ModuleConfigRegistryTest(TestCase):
         self.assertEqual(calls, ["a"])
 
     def test_validate_propagates_validation_error(self):
-        register_validator("mod_x", lambda inst: (_ for _ in ()).throw(ValidationError("bad config")))
+        def bad_validator(instance):
+            raise ValidationError("bad config")
+
+        register_validator("mod_x", bad_validator)
         instance = ModuleConfiguration(module="mod_x", layer="be", version="1", config="{}")
 
         with self.assertRaises(ValidationError):
@@ -80,3 +82,24 @@ class ModuleConfigRegistryTest(TestCase):
         instance = ModuleConfiguration(module="unregistered", layer="be", version="1", config="{}")
         validate_module_configuration(instance)
         reload_module_configuration(instance)
+
+    def test_save_validates_before_persist(self):
+        def reject_all(instance):
+            raise ValidationError("blocked")
+
+        register_validator("save_test", reject_all)
+        mc = ModuleConfiguration(module="save_test", layer="be", version="1", config="{}")
+
+        with self.assertRaises(ValidationError):
+            mc.save()
+
+        self.assertFalse(ModuleConfiguration.objects.filter(pk=mc.pk).exists())
+
+    def test_save_reloads_after_persist(self):
+        reloaded = []
+        register_reloader("reload_test", lambda inst: reloaded.append(inst.module))
+
+        mc = ModuleConfiguration(module="reload_test", layer="be", version="1", config="{}")
+        mc.save()
+        self.assertEqual(reloaded, ["reload_test"])
+        mc.delete()

--- a/core/tests/test_module_config_registry.py
+++ b/core/tests/test_module_config_registry.py
@@ -86,6 +86,12 @@ class ModuleConfigRegistryTest(TestCase):
         validate_module_configuration(instance)
         reload_module_configuration(instance)
 
+    def test_save_rejects_invalid_json(self):
+        mc = ModuleConfiguration(module="test", layer="be", version="1", config="{bad")
+        with self.assertRaises(ValidationError):
+            mc.save()
+        self.assertFalse(ModuleConfiguration.objects.filter(pk=mc.pk).exists())
+
     def test_save_validates_before_persist(self):
         def reject_all(instance):
             raise ValidationError("blocked")

--- a/core/tests/test_module_config_registry.py
+++ b/core/tests/test_module_config_registry.py
@@ -104,11 +104,12 @@ class ModuleConfigRegistryTest(TestCase):
 
         self.assertFalse(ModuleConfiguration.objects.filter(pk=mc.pk).exists())
 
-    def test_save_reloads_after_persist(self):
+    def test_save_reloads_after_commit(self):
         reloaded = []
         register_reloader("reload_test", lambda inst: reloaded.append(inst.module))
 
         mc = ModuleConfiguration(module="reload_test", layer="be", version="1", config="{}")
-        mc.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            mc.save()
         self.assertEqual(reloaded, ["reload_test"])
         mc.delete()


### PR DESCRIPTION
# Description

Provide centralized management of module config validations and reload. With this change set, other modules will be able to optionally register their validation functions and reload functions. 

- If a module registers a validation, it will be triggered at the time when the config is saved. This way invalid config will not be allowed to be saved, which is better than the status quo where the module configs are only validated at app start time.
- If the module registers a reload function the config will be live reloaded without requiring app restart.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [x] Relates to https://github.com/openimis/openimis-be-grievance_social_protection_py/pull/38
- [ ] External reference (e.g., Jira):

## Demo

<img width="1072" height="1162" alt="Screenshot 2026-05-08 at 4 33 04 PM" src="https://github.com/user-attachments/assets/6539f474-bd15-4eb3-b194-6774f77afdd5" />

## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
