### PR TITLE
Fix: no change save no op

### DIFF
--- a/core/models/history_model.py
+++ b/core/models/history_model.py
@@ -242,10 +242,7 @@ class HistoryModel(DirtyFieldsMixin, CachedModelMixin, Model):
             result = super().save(*args, **kwargs)
             self.update_cache()
             return result
-        else:
-            raise ValidationError(
-                "Record has not be updated - there are no changes in fields"
-            )
+        return None
 
     def delete_history(self):
         pass

--- a/core/models/openimis_model.py
+++ b/core/models/openimis_model.py
@@ -97,10 +97,7 @@ class OpenIMISHistoryMixin(DirtyFieldsMixin, CachedModelMixin, Model):
             result = super().save(*args, **kwargs)
             self.update_cache()
             return result
-        else:
-            raise ValidationError(
-                "Record has not be updated - there are no changes in fields"
-            )
+        return None
 
     def delete_history(self):
         pass

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -1,6 +1,11 @@
-from django.test import TestCase
+from unittest.mock import MagicMock
+
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
 from core.models import User, TechnicalUser, InteractiveUser
+from core.models.history_model import HistoryModel
 from core.models.user import Language
 from core.utils import get_cache_key
 
@@ -160,3 +165,51 @@ class UserTestCase(TestCase):
             ),
         )
         self.assertFalse(not_active_anymore.is_active)
+
+
+class SaveNoOpTestCase(TestCase):
+    """Re-saving an existing instance with no dirty fields must be a silent no-op:
+    no ValidationError, no version bump, no new history row.
+
+    Guards both base-class save() implementations:
+      - core.models.openimis_model.OpenIMISHistoryMixin.save (covered end-to-end via InteractiveUser)
+      - core.models.history_model.HistoryModel.save (covered via direct MagicMock invocation,
+        since core has no concrete HistoryBusinessModel subclass)
+    """
+
+    def test_openimis_model_save_is_noop_when_not_dirty(self):
+        cache.clear()
+        language, _ = Language.objects.get_or_create(
+            code="en", defaults={"name": "English", "sort_order": 1}
+        )
+        user = InteractiveUser.objects.create(
+            login_name="noop_save_user",
+            last_name="NoOp",
+            other_names="Test",
+            language=language,
+        )
+        baseline_version = user.version
+        baseline_history_count = user.history.count()
+
+        result = user.save()
+
+        self.assertIsNone(result)
+        user.refresh_from_db()
+        self.assertEqual(user.version, baseline_version)
+        self.assertEqual(user.history.count(), baseline_history_count)
+
+
+    def test_history_model_save_is_noop_when_not_dirty(self):
+        instance = MagicMock()
+        instance.id = "existing-id"
+        instance.version = 7
+        instance.is_dirty.return_value = False
+
+        try:
+            result = HistoryModel.save(instance)
+        except ValidationError:
+            self.fail("HistoryModel.save should not raise on a no-op save")
+
+        self.assertIsNone(result)
+        self.assertEqual(instance.version, 7)
+        instance.is_dirty.assert_called_with(check_relationship=True)


### PR DESCRIPTION
# Description

When a model instance is not dirty and save is called, raising ValidationError is very aggressively unnecessary and creates noise downstream (task management, admin interface, UI etc.) This PR changes that to no-op instead and ensure that no new history version is created (see added tests).

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Before:
[Upload screenshots/gifs or link to any demo video here.](https://github.com/openimis/openimis-be-core_py/pull/new/fix/no-change-save-no-op)

After (aligned with default Django behavior):
<img width="1072" height="1162" alt="image" src="https://github.com/user-attachments/assets/0b42f58b-991d-4c6f-b9f0-8d32ca48f0dd" />


## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled
