### PR TITLE
feat(core): implements fields max length service

### DIFF
--- a/core/gql/__init__.py
+++ b/core/gql/__init__.py
@@ -1,0 +1,5 @@
+# core/gql/__init__.py
+
+from .max_length_constraints import MaxLengthConstraintsGQLType, build_max_length_constraints
+
+__all__ = ['MaxLengthConstraintsGQLType', 'build_max_length_constraints']

--- a/core/gql/max_length_constraints.py
+++ b/core/gql/max_length_constraints.py
@@ -1,0 +1,93 @@
+# core/gql/max_length_constraints.py
+
+from graphene.types.generic import GenericScalar
+import graphene
+from django.apps import apps
+
+try:
+    from insuree.models import Insuree
+except ImportError:
+    Insuree = None
+
+
+def get_model(model_name):
+    """Récupère un modèle à partir de son nom."""
+    try:
+        return apps.get_model('core', model_name)
+    except LookupError:
+        return None
+
+
+MAX_LENGTH_CONSTRAINTS_FIELDS = {
+    "admin": {
+        "user": {
+            "username": ("User", "username"),
+            "lastName": ("InteractiveUser", "last_name"),
+            "otherNames": ("InteractiveUser", "other_names"),
+            "phone": ("InteractiveUser", "phone"),
+            "email": ("InteractiveUser", "email"),
+        },
+    },
+}
+
+if Insuree:
+    MAX_LENGTH_CONSTRAINTS_FIELDS["insuree"] = {
+        "insuree": {
+            "uuid": (Insuree, "uuid"),
+            "chfId": (Insuree, "chf_id"),
+            "lastName": (Insuree, "last_name"),
+            "otherNames": (Insuree, "other_names"),
+            "marital": (Insuree, "marital"),
+            "passport": (Insuree, "passport"),
+            "phone": (Insuree, "phone"),
+            "email": (Insuree, "email"),
+            "currentAddress": (Insuree, "current_address"),
+            "geolocation": (Insuree, "geolocation"),
+            "status": (Insuree, "status"),
+        },
+    }
+
+
+def build_max_length_constraints():
+    constraints = {}
+
+    for module_name, forms in MAX_LENGTH_CONSTRAINTS_FIELDS.items():
+        module_constraints = {}
+
+        for form_name, fields in forms.items():
+            form_constraints = {}
+
+            for field_name, (model_or_name, model_field_name) in fields.items():
+                if isinstance(model_or_name, str):
+                    model = get_model(model_or_name)
+                    if model is None:
+                        continue
+                else:
+                    model = model_or_name
+
+                try:
+                    field = model._meta.get_field(model_field_name)
+                    if field.max_length:
+                        form_constraints[field_name] = field.max_length
+                except Exception:
+                    continue
+
+            if form_constraints:
+                module_constraints[form_name] = form_constraints
+
+        if module_constraints:
+            constraints[module_name] = module_constraints
+
+    return constraints
+
+
+class MaxLengthConstraintsGQLType(graphene.ObjectType):
+    """
+    Returns max_length constraints used by the frontend to enforce field length
+    limits in supported forms.
+    """
+    constraints = GenericScalar()
+
+    @staticmethod
+    def resolve_constraints(root, info):
+        return build_max_length_constraints()

--- a/core/gql_queries.py
+++ b/core/gql_queries.py
@@ -16,7 +16,8 @@ from location.models import HealthFacility, UserDistrict
 from core.apps import CoreConfig
 from django.utils.translation import gettext as _
 from django.core.exceptions import PermissionDenied
-
+from graphene.types.generic import GenericScalar
+from .gql import MaxLengthConstraintsGQLType, build_max_length_constraints
 from .utils import prefix_filterset
 
 class OfficerGQLType(DjangoObjectType):

--- a/core/schema.py
+++ b/core/schema.py
@@ -69,6 +69,7 @@ from core.gql_queries import (
     PermissionOpenImisGQLType,
     ModulePermissionGQLType,
     CustomFilterOptionGQLType,
+    MaxLengthConstraintsGQLType,
 )
 from core.utils import (  # noqa: 401
     ExtendedConnection,
@@ -758,6 +759,8 @@ class Query(graphene.ObjectType):
         ModuleConfigurationGQLType, validity=graphene.String(), layer=graphene.String()
     )
 
+    max_length_constraints = graphene.Field(MaxLengthConstraintsGQLType)
+
     user_obligatory_fields = GenericScalar()
     eo_obligatory_fields = GenericScalar()
 
@@ -967,6 +970,9 @@ class Query(graphene.ObjectType):
             return False
         else:
             return True
+
+    def resolve_max_length_constraints(self, info):
+        return MaxLengthConstraintsGQLType()
 
     def resolve_validate_user_email(self, info, **kwargs):
         if not info.context.user.has_perms(CoreConfig.gql_query_users_perms):

--- a/core/tests/test_gql_queries.py
+++ b/core/tests/test_gql_queries.py
@@ -1,0 +1,58 @@
+from django.test import TestCase
+
+from core.gql.max_length_constraints import build_max_length_constraints
+
+try:
+    from insuree.models import Insuree
+except ImportError:
+    Insuree = None
+
+
+class MaxLengthConstraintsTestCase(TestCase):
+    def test_build_max_length_constraints_returns_supported_admin_user_fields(self):
+        constraints = build_max_length_constraints()
+
+        self.assertIn("admin", constraints)
+        self.assertIn("user", constraints["admin"])
+        self.assertEqual(
+            constraints["admin"]["user"],
+            {
+                "username": 50,
+                "lastName": 100,
+                "otherNames": 100,
+                "phone": 50,
+                "email": 200,
+            },
+        )
+
+    def test_build_max_length_constraints_excludes_uncontrolled_models(self):
+        constraints = build_max_length_constraints()
+
+        self.assertNotIn("logentry", constraints)
+        self.assertNotIn("session", constraints)
+        self.assertNotIn("historicalinteractiveuser", constraints)
+
+    def test_build_max_length_constraints_returns_insuree_fields_when_available(self):
+        if not Insuree:
+            self.skipTest("Insuree module is not installed")
+
+        constraints = build_max_length_constraints()
+
+        self.assertIn("insuree", constraints)
+        self.assertIn("insuree", constraints["insuree"])
+        self.assertEqual(
+            constraints["insuree"]["insuree"],
+            {
+                "uuid": 36,
+                "chfId": 50,
+                "lastName": 100,
+                "otherNames": 100,
+                "marital": 1,
+                "passport": 25,
+                "phone": 50,
+                "email": 100,
+                "currentAddress": 200,
+                "geolocation": 250,
+                "status": 2,
+            },
+        )


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

In Openimis, several backend models enforce maximum field lengths (`max_length`). Consequently, when the frontend sends a payload with fields exceeding these limits, the backend returns an error message for the mutation. To prevent users from encountering this—given that the backend error message is not particularly user-friendly—we implemented a service that blocks further input once the `max_length` is reached and displays a message to inform the user (see screenshot).

The implemented approach is as follows:

On the backend, a new type is added to the queries: `MaxLengthConstraintsGQLType`

Expected payload:

`query GetMaxLengthConstraints {
  maxLengthConstraints {
    constraints
  }
}`

which returns something like:

`{
  "data": {
    "maxLengthConstraints": {
       "insuree": {
          "uuid": 36,
          "chfId": 50,
          "lastName": 100,
          "otherNames": 100,
          "marital": 1,
          "passport": 25,
          "phone": 50,
          "email": 100,
          "currentAddress": 200,
          "geolocation": 250,
          "status": 2
        }
       }
     }
   }`

On the frontend, this payload is retrieved, and component properties are used to identify the `max_length` for the current field and manage user interaction.

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [x] Enhancement

## Related Issue(s) / Task(s)
- [x] Relates to https://github.com/openimis/openimis-fe-core_js/pull/333
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
