### PR TITLE
Fix id_for_audit returning the built-in id function instead of self.id

### DIFF
--- a/core/models/user.py
+++ b/core/models/user.py
@@ -239,7 +239,7 @@ class InteractiveUser(OpenIMISMigrationModel):
 
     @property
     def id_for_audit(self):
-        return id
+        return self.id
 
     @property
     def username(self):
@@ -454,7 +454,7 @@ class Officer(VersionedModel, ExtendableModel):
 
     @property
     def id_for_audit(self):
-        return id
+        return self.id
 
     @property
     def username(self):

--- a/core/tests/test_id_for_audit.py
+++ b/core/tests/test_id_for_audit.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+from core.models import InteractiveUser, Officer
+
+
+class IdForAuditRegressionTestCase(TestCase):
+    """Regression tests for id_for_audit returning Python's built-in `id`
+    function instead of the record id.
+
+    Any service stamping audit_user_id from these models crashed with
+    ValidationError: "<built-in function id>" value must be an integer
+    (e.g. contribution.services.create_premium)."""
+
+    def test_interactive_user_id_for_audit_is_the_record_id(self):
+        user = InteractiveUser(id=42)
+        self.assertEqual(user.id_for_audit, 42)
+        self.assertNotEqual(user.id_for_audit, id)
+
+    def test_officer_id_for_audit_is_the_record_id(self):
+        officer = Officer(id=7)
+        self.assertEqual(officer.id_for_audit, 7)
+        self.assertNotEqual(officer.id_for_audit, id)


### PR DESCRIPTION
## The bug

`InteractiveUser.id_for_audit` and `Officer.id_for_audit` in `core/models/user.py` contain a bare `return id` — which returns **Python's built-in `id` function**, not the record's id.

Any service that stamps `audit_user_id` from these models crashes. For example, `contribution.services.create_premium` fails with:

```
ValidationError: "<built-in function id>" value must be an integer
```

## The fix

Both properties now `return self.id`, matching the behaviour of `ClaimAdmin.id_for_audit`. Regression tests included (`core/tests/test_id_for_audit.py`).

## Context

Found during the **KeHIA × @iLabAfrica Digital Health Financing Hackathon 2026** while building [MediTrust](https://github.com/CodeWithEugene/openimis-be-core_py) — a mobile-premiums / participatory-claim-verification / FHIR-R4 pre-adjudication extension on this module — where creating a real `Premium` through `contribution.services` first exposed the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)