### PR TITLE
fix(core): invalidate rights cache on role, role right and user role changes - OP-3073

### DIFF
--- a/core/receivers.py
+++ b/core/receivers.py
@@ -3,25 +3,35 @@ import sys
 from django.apps import apps
 from django.db.models.signals import post_save, post_delete
 from contextlib import suppress
-from core.models.user import Officer, Role
+from core.models.user import Officer, Role, RoleRight, UserRole
 from django.core.cache import cache
-from django_redis.cache import RedisCache
+
+
+def _clear_all_rights_cache():
+    # rights are cached per user id, so a role-level change cannot target a single key
+    delete_pattern = getattr(cache, "delete_pattern", None)
+    if delete_pattern:
+        delete_pattern("rights_*")
+    else:
+        cache.clear()
 
 
 @receiver([post_save, post_delete], sender=Officer)
 def _post_save_eo_receiver(sender, instance, **kwargs):
     with suppress(AttributeError):
         cache.delete(f"user_eo_{instance.code}")
-        cache.delete(f"rights_{instance.code}")
 
 
 @receiver([post_save, post_delete], sender=Role)
+@receiver([post_save, post_delete], sender=RoleRight)
 def _post_save_rolerights_receiver(sender, instance, **kwargs):
-    with suppress(AttributeError):
-        if isinstance(cache, RedisCache):
-            cache.delete("rights_*")
-        else:
-            cache.clear()
+    _clear_all_rights_cache()
+
+
+@receiver([post_save, post_delete], sender=UserRole)
+def _post_save_userrole_receiver(sender, instance, **kwargs):
+    cache.delete(f"rights_{instance.user_id}")
+    cache.delete(f"is_admin_{instance.user_id}")
 
 
 if "claim" in sys.modules:
@@ -31,4 +41,3 @@ if "claim" in sys.modules:
     def _post_save_ca_receiver(sender, instance, **kwargs):
         with suppress(AttributeError):
             cache.delete(f"user_ca_{instance.code}")
-            cache.delete(f"rights_{instance.code}")

--- a/core/receivers.py
+++ b/core/receivers.py
@@ -12,6 +12,7 @@ def _clear_all_rights_cache():
     delete_pattern = getattr(cache, "delete_pattern", None)
     if delete_pattern:
         delete_pattern("rights_*")
+        delete_pattern("is_admin_*")
     else:
         cache.clear()
 

--- a/core/tests/test_rights_cache.py
+++ b/core/tests/test_rights_cache.py
@@ -105,8 +105,17 @@ class RoleChangeCacheInvalidationTest(TestCase):
             self.role.name = "TestRoleChangeCacheRoleRenamed"
             self.role.save()
 
-        self.assertEqual(["rights_*"], stub.deleted_patterns)
+        self.assertIn("rights_*", stub.deleted_patterns)
         self.assertFalse(stub.cleared)
+
+    def test_role_change_deletes_is_admin_keys_by_pattern_when_supported(self):
+        stub = PatternCacheStub(supports_patterns=True)
+
+        with patch("core.receivers.cache", stub):
+            self.role.is_system = 64
+            self.role.save()
+
+        self.assertIn("is_admin_*", stub.deleted_patterns)
 
     def test_role_change_clears_cache_when_patterns_unsupported(self):
         stub = PatternCacheStub(supports_patterns=False)

--- a/core/tests/test_rights_cache.py
+++ b/core/tests/test_rights_cache.py
@@ -1,0 +1,118 @@
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from core.models import Role, RoleRight, UserRole
+from core.test_helpers import create_test_interactive_user
+
+BASE_RIGHT_ID = 999000
+ADDED_RIGHT_ID = 999001
+OTHER_ROLE_RIGHT_ID = 999002
+
+
+def create_role(name):
+    return Role.objects.create(
+        name=name, is_system=0, is_blocked=False, audit_user_id=-1
+    )
+
+
+class RightsCacheInvalidationTest(TestCase):
+    def setUp(self):
+        self.role = create_role("TestRightsCacheRole")
+        RoleRight.objects.create(
+            role=self.role, right_id=BASE_RIGHT_ID, audit_user_id=-1
+        )
+        self.user = create_test_interactive_user(
+            username="TestRightsCacheUser", roles=[self.role.id]
+        )
+        self.i_user = self.user.i_user
+        cache.clear()
+
+    def test_adding_role_right_invalidates_rights_cache(self):
+        self.assertEqual([BASE_RIGHT_ID], self.i_user.rights)
+
+        RoleRight.objects.create(
+            role=self.role, right_id=ADDED_RIGHT_ID, audit_user_id=-1
+        )
+
+        self.assertIn(ADDED_RIGHT_ID, self.i_user.rights)
+
+    def test_removing_role_right_invalidates_rights_cache(self):
+        role_right = RoleRight.objects.create(
+            role=self.role, right_id=ADDED_RIGHT_ID, audit_user_id=-1
+        )
+        cache.clear()
+        self.assertIn(ADDED_RIGHT_ID, self.i_user.rights)
+
+        role_right.delete()
+
+        self.assertNotIn(ADDED_RIGHT_ID, self.i_user.rights)
+        self.assertIn(BASE_RIGHT_ID, self.i_user.rights)
+
+    def test_assigning_role_to_user_invalidates_rights_cache(self):
+        other_role = create_role("TestRightsCacheOtherRole")
+        RoleRight.objects.create(
+            role=other_role, right_id=OTHER_ROLE_RIGHT_ID, audit_user_id=-1
+        )
+        cache.clear()
+        self.assertEqual([BASE_RIGHT_ID], self.i_user.rights)
+
+        UserRole.objects.create(user=self.i_user, role=other_role, audit_user_id=-1)
+
+        self.assertIn(OTHER_ROLE_RIGHT_ID, self.i_user.rights)
+
+    def test_assigning_admin_role_invalidates_is_admin_cache(self):
+        admin_role = Role.objects.create(
+            name="TestRightsCacheAdminRole",
+            is_system=64,
+            is_blocked=False,
+            audit_user_id=-1,
+        )
+        self.assertFalse(self.i_user.is_imis_admin)
+
+        UserRole.objects.create(user=self.i_user, role=admin_role, audit_user_id=-1)
+
+        self.assertTrue(self.i_user.is_imis_admin)
+
+
+class PatternCacheStub:
+    def __init__(self, supports_patterns):
+        self.deleted_keys = []
+        self.deleted_patterns = []
+        self.cleared = False
+        if supports_patterns:
+            self.delete_pattern = self._delete_pattern
+
+    def _delete_pattern(self, pattern):
+        self.deleted_patterns.append(pattern)
+
+    def delete(self, key):
+        self.deleted_keys.append(key)
+
+    def clear(self):
+        self.cleared = True
+
+
+class RoleChangeCacheInvalidationTest(TestCase):
+    def setUp(self):
+        self.role = create_role("TestRoleChangeCacheRole")
+
+    def test_role_change_deletes_rights_keys_by_pattern_when_supported(self):
+        stub = PatternCacheStub(supports_patterns=True)
+
+        with patch("core.receivers.cache", stub):
+            self.role.name = "TestRoleChangeCacheRoleRenamed"
+            self.role.save()
+
+        self.assertEqual(["rights_*"], stub.deleted_patterns)
+        self.assertFalse(stub.cleared)
+
+    def test_role_change_clears_cache_when_patterns_unsupported(self):
+        stub = PatternCacheStub(supports_patterns=False)
+
+        with patch("core.receivers.cache", stub):
+            self.role.name = "TestRoleChangeCacheRoleRenamed"
+            self.role.save()
+
+        self.assertTrue(stub.cleared)


### PR DESCRIPTION
# Description

`cache.delete("rights_*")` in `core/receivers.py` was a no-op: the Django cache API has no wildcard delete. On Redis deployments (`CACHE_BACKEND=django_redis.cache.RedisCache`) a role change therefore never dropped the per-user rights cache, which `InteractiveUser.rights` stores with `timeout=None` — so stale rights survived indefinitely. Only the non-Redis fallback (`cache.clear()`, the LocMemCache default used locally) actually worked, which is why this reproduces on staging/release but not on a developer machine.

Three related gaps are fixed:

- Role changes now use `delete_pattern("rights_*")` when the cache backend exposes it, keeping `cache.clear()` as the fallback. Detection is duck-typed, which also removes the module-level `django_redis` import.
- `RoleRight` and `UserRole` had no receiver at all, so editing the rights of a role or assigning a role to a user left stale entries. `UserRole` invalidation is targeted (`rights_{user_id}`) and also drops `is_admin_{user_id}`, which gates the superuser shortcut in `InteractiveUser.rights`.
- The `Officer` and `ClaimAdmin` receivers deleted `rights_{instance.code}` while the cache key is `rights_{i_user.id}`. Those deletes could never match a real key, and on numeric officer codes could only collide with an unrelated user's entry — removed.

No change was needed in `core/schema.py`: `update_or_create_role` calls `role.save()` before rewriting the role rights, so the `Role` receiver already fires on that path.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)

- External reference (e.g., Jira): OP-3073, related OP-3007

## Demo

Not applicable — cache invalidation, covered by unit tests. To reproduce the original bug: run the backend with `CACHE_BACKEND=django_redis.cache.RedisCache`, log in as a non-admin user, read any permission-gated page, then change that user's role rights. Before this change the old rights are served until the Redis key is dropped by hand.

## Checklist

- [x] Unit tests added/modified
- [ ] I18n / translation handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
